### PR TITLE
Add AGENTS.md template to project generator

### DIFF
--- a/tools/project/embed_template_generator_test.go
+++ b/tools/project/embed_template_generator_test.go
@@ -1,7 +1,6 @@
 package project
 
 import (
-
 	"errors"
 	"fmt"
 	"io"
@@ -15,7 +14,6 @@ import (
 
 func TestGenerateProjectCreatesExecutableScripts(t *testing.T) {
 
-
 	tempDir := t.TempDir()
 
 	generator := NewEmbedTemplateGenerator(
@@ -27,6 +25,10 @@ func TestGenerateProjectCreatesExecutableScripts(t *testing.T) {
 
 	if err := generator.Generate(); err != nil {
 		t.Fatalf("Generate() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tempDir, "AGENTS.md")); err != nil {
+		t.Fatalf("expected AGENTS.md to be generated: %v", err)
 	}
 
 	scriptPath := filepath.Join(tempDir, "scripts", "dev.sh")
@@ -46,7 +48,6 @@ func TestGenerateProjectCreatesExecutableScripts(t *testing.T) {
 	if !strings.Contains(string(goModBytes), "module github.com/example/demo") {
 		t.Fatalf("go.mod does not contain module path: %s", goModBytes)
 	}
-
 
 	if _, err := os.Stat(filepath.Join(tempDir, "go.sum")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected go.sum to be skipped, got err=%v", err)
@@ -114,7 +115,6 @@ func TestGenerateProjectSanitizesNames(t *testing.T) {
 
 func TestGenerateProjectWithCustomLoggerAndModes(t *testing.T) {
 
-
 	tempDir := t.TempDir()
 	var logBuilder strings.Builder
 
@@ -163,7 +163,6 @@ func TestRunWithWriterUsesProvidedOutput(t *testing.T) {
 
 	t.Parallel()
 
-
 	tempDir := t.TempDir()
 	targetDir := filepath.Join(tempDir, "myapp")
 
@@ -185,7 +184,6 @@ func TestRunWithWriterUsesProvidedOutput(t *testing.T) {
 		t.Fatalf("expected go.mod to be generated: %v", err)
 	}
 }
-
 
 func TestRunWithWriterRejectsInvalidModulePath(t *testing.T) {
 	tempDir := t.TempDir()
@@ -236,4 +234,3 @@ func TestRunWithWriterRejectsDangerousForce(t *testing.T) {
 		t.Fatalf("返回的错误信息不包含预期提示: %v", err)
 	}
 }
-

--- a/tools/project/templates/AGENTS.md.tmpl
+++ b/tools/project/templates/AGENTS.md.tmpl
@@ -1,0 +1,9 @@
+# Repository Development Notes
+
+This project scaffolds API layers (service, biz, data) from OpenAPI descriptions. When adding or modifying functionality under `internal/api`, keep the following in mind:
+
+- **OpenAPI as the source of truth**: the base structs and interfaces for the service, biz, and data layers are generated automatically from the OpenAPI specification. Avoid making manual changes that would be overwritten by regeneration.
+- **Extending generated layers**: place custom logic in separate files or clearly marked extension points so that automation can build atop the generated foundations without merge conflicts.
+- **Consistent layer responsibilities**: ensure changes respect the layering contract documented in `README.md`—services expose transport logic, biz coordinates domain rules, and data talks to storage. This keeps the generated code predictable for downstream automation.
+
+When updating templates or tooling that emits these layers, verify that regeneration from the OpenAPI definition still produces compilable artifacts before merging.


### PR DESCRIPTION
## Summary
- add an AGENTS.md template to the project scaffolding assets so generated projects include repository guidance
- extend the generator test to assert the AGENTS.md file is produced alongside other assets

## Testing
- go test -run TestGenerateProjectCreatesExecutableScripts -count=1 -v ./tools/project

------
https://chatgpt.com/codex/tasks/task_e_68d65823cdb0832d9574d031d5a072fc