### PR TITLE
Fix service templates to include context and resp helpers

### DIFF
--- a/muban/project/templates/internal/api/service/example_router.go.tmpl
+++ b/muban/project/templates/internal/api/service/example_router.go.tmpl
@@ -1,11 +1,9 @@
 package service
 
 import (
-	"net/http"
-
-	"{{.ModulePath}}/internal/resp"
-	"github.com/labstack/echo/v4"
-	"go.uber.org/fx"
+        "{{.ModulePath}}/internal/resp"
+        "github.com/labstack/echo/v4"
+        "go.uber.org/fx"
 )
 
 // ExampleRouter 示例路由
@@ -13,125 +11,117 @@ type ExampleRouter struct{}
 
 // NewExampleRouter 创建示例路由
 func NewExampleRouter() *ExampleRouter {
-	return &ExampleRouter{}
+        return &ExampleRouter{}
 }
 
 // RegisterRouter 注册路由
 func (r *ExampleRouter) RegisterRouter(g *echo.Group, middlewareFunc ...echo.MiddlewareFunc) {
-	// 用户相关路由
-	users := g.Group("/users")
-	users.GET("", r.GetUsers)
-	users.GET("/:id", r.GetUser)
-	users.POST("", r.CreateUser)
-	users.PUT("/:id", r.UpdateUser)
-	users.DELETE("/:id", r.DeleteUser)
+        users := g.Group("/users")
+        users.GET("", r.GetUsers)
+        users.GET("/:id", r.GetUser)
+        users.POST("", r.CreateUser)
+        users.PUT("/:id", r.UpdateUser)
+        users.DELETE("/:id", r.DeleteUser)
 
-	// 系统信息路由
-	system := g.Group("/system")
-	system.GET("/info", r.GetSystemInfo)
-	system.GET("/version", r.GetVersion)
+        system := g.Group("/system")
+        system.GET("/info", r.GetSystemInfo)
+        system.GET("/version", r.GetVersion)
 }
 
 // GetUsers 获取用户列表
 func (r *ExampleRouter) GetUsers(c echo.Context) error {
-	// 示例数据
-	users := []map[string]interface{}{
-		{"id": 1, "name": "张三", "email": "zhangsan@example.com"},
-		{"id": 2, "name": "李四", "email": "lisi@example.com"},
-	}
-	return c.JSON(http.StatusOK, resp.Success(users))
+        users := []map[string]interface{}{
+                {"id": 1, "name": "张三", "email": "zhangsan@example.com"},
+                {"id": 2, "name": "李四", "email": "lisi@example.com"},
+        }
+        return resp.ListDataResponse(users, int64(len(users)), c)
 }
 
 // GetUser 获取单个用户
 func (r *ExampleRouter) GetUser(c echo.Context) error {
-	id := c.Param("id")
-	user := map[string]interface{}{
-		"id":    id,
-		"name":  "示例用户",
-		"email": "user@example.com",
-	}
-	return c.JSON(http.StatusOK, resp.Success(user))
+        id := c.Param("id")
+        user := map[string]interface{}{
+                "id":    id,
+                "name":  "示例用户",
+                "email": "user@example.com",
+        }
+        return resp.OneDataResponse(user, c)
 }
 
 // CreateUser 创建用户
 func (r *ExampleRouter) CreateUser(c echo.Context) error {
-	var req struct {
-		Name  string `json:"name" validate:"required"`
-		Email string `json:"email" validate:"required,email"`
-	}
+        var req struct {
+                Name  string `json:"name" validate:"required"`
+                Email string `json:"email" validate:"required,email"`
+        }
 
-	if err := BindAndValidate(c, &req); err != nil {
-		return err
-	}
+        if err := BindAndValidate(c, &req); err != nil {
+                return err
+        }
 
-	// 模拟创建用户
-	user := map[string]interface{}{
-		"id":    3,
-		"name":  req.Name,
-		"email": req.Email,
-	}
+        user := map[string]interface{}{
+                "id":    3,
+                "name":  req.Name,
+                "email": req.Email,
+        }
 
-	return c.JSON(http.StatusCreated, resp.Success(user))
+        return resp.OneDataResponse(user, c)
 }
 
 // UpdateUser 更新用户
 func (r *ExampleRouter) UpdateUser(c echo.Context) error {
-	id := c.Param("id")
-	var req struct {
-		Name  string `json:"name"`
-		Email string `json:"email" validate:"email"`
-	}
+        id := c.Param("id")
+        var req struct {
+                Name  string `json:"name"`
+                Email string `json:"email" validate:"email"`
+        }
 
-	if err := BindAndValidate(c, &req); err != nil {
-		return err
-	}
+        if err := BindAndValidate(c, &req); err != nil {
+                return err
+        }
 
-	// 模拟更新用户
-	user := map[string]interface{}{
-		"id":    id,
-		"name":  req.Name,
-		"email": req.Email,
-	}
+        user := map[string]interface{}{
+                "id":    id,
+                "name":  req.Name,
+                "email": req.Email,
+        }
 
-	return c.JSON(http.StatusOK, resp.Success(user))
+        return resp.OneDataResponse(user, c)
 }
 
 // DeleteUser 删除用户
 func (r *ExampleRouter) DeleteUser(c echo.Context) error {
-	id := c.Param("id")
-	return c.JSON(http.StatusOK, resp.Success(map[string]string{
-		"message": "用户删除成功",
-		"id":      id,
-	}))
+        _ = c.Param("id")
+        return resp.OperateSuccess(c)
 }
 
 // GetSystemInfo 获取系统信息
 func (r *ExampleRouter) GetSystemInfo(c echo.Context) error {
-	info := map[string]interface{}{
-            "name":    "{{.DisplayName}}",
-		"version": "1.0.0",
-		"status":  "running",
-		"uptime":  "1h 30m",
-	}
-	return c.JSON(http.StatusOK, resp.Success(info))
+        info := map[string]interface{}{
+                "name":    "{{.DisplayName}}",
+                "version": "1.0.0",
+                "status":  "running",
+                "uptime":  "1h 30m",
+        }
+        return resp.OneDataResponse(info, c)
 }
 
 // GetVersion 获取版本信息
 func (r *ExampleRouter) GetVersion(c echo.Context) error {
-	version := map[string]string{
-		"version": "1.0.0",
-		"build":   "2024-01-01",
-		"commit":  "abc123",
-	}
-	return c.JSON(http.StatusOK, resp.Success(version))
+        version := map[string]string{
+                "version": "1.0.0",
+                "build":   "2024-01-01",
+                "commit":  "abc123",
+        }
+        return resp.OneDataResponse(version, c)
 }
 
 // ExampleRouterModule 示例路由模块
 var ExampleRouterModule = fx.Options(
-	fx.Provide(NewExampleRouter),
-	fx.Provide(fx.Annotate(
-		NewExampleRouter,
-		fx.As(new(RegisterRouter)),
-		fx.ResultTags(`group:"routes"`),
-	)),
+        fx.Provide(NewExampleRouter),
+        fx.Provide(fx.Annotate(
+                NewExampleRouter,
+                fx.As(new(RegisterRouter)),
+                fx.ResultTags(`group:"routes"`),
+        )),
 )

--- a/muban/project/templates/internal/resp/response.go.tmpl
+++ b/muban/project/templates/internal/resp/response.go.tmpl
@@ -7,164 +7,145 @@
 package resp
 
 import (
-	"net/http"
-	"reflect"
-	"time"
+        "net/http"
+        "reflect"
+        "time"
 
-	"log/slog"
+        "log/slog"
 
-	"{{.ModulePath}}/internal/code"
-	"{{.ModulePath}}/internal/log"
-	"github.com/google/uuid"
-	"github.com/labstack/echo/v4"
-	"github.com/marmotedu/errors"
+        "{{.ModulePath}}/internal/code"
+        "{{.ModulePath}}/internal/log"
+        "github.com/google/uuid"
+        "github.com/labstack/echo/v4"
+        "github.com/marmotedu/errors"
 )
 
 type ListResponse struct {
-	Code int      `json:"code"`
-	Msg  string   `json:"msg"`
-	Data ListData `json:"data"`
+        Code int      `json:"code"`
+        Msg  string   `json:"msg"`
+        Data ListData `json:"data"`
 }
 
 type ListData struct {
-	Total int64       `json:"total"`
-	List  interface{} `json:"list" `
+        Total int64       `json:"total"`
+        List  interface{} `json:"list" `
 }
 
 type DataResponse struct {
-	Code int         `json:"code"`
-	Msg  string      `json:"msg"`
-	Data interface{} `json:"data"`
+        Code int         `json:"code"`
+        Msg  string      `json:"msg"`
+        Data interface{} `json:"data"`
 }
 
 // ErrorResponse 统一错误响应结构
 type ErrorResponse struct {
-	Code      int    `json:"code"`       // 业务错误码
-	Message   string `json:"message"`    // 错误消息
-	RequestID string `json:"request_id"` // 请求ID（用于追踪）
-	Timestamp int64  `json:"timestamp"`  // 错误发生时间戳
+        Code      int    `json:"code"`       // 业务错误码
+        Message   string `json:"message"`    // 错误消息
+        RequestID string `json:"request_id"` // 请求ID（用于追踪）
+        Timestamp int64  `json:"timestamp"`  // 错误发生时间戳
 }
 
 // APIError 返回API错误
 func APIError(err error, c echo.Context) error {
-	if err == nil {
-		return errors.New("error can't be nil")
-	}
+        if err == nil {
+                return errors.New("error can't be nil")
+        }
 
-	// 解析错误码
-	codeError := errors.ParseCoder(err)
-	if codeError == nil {
-		err = code.WrapInternalServerError(err, "internal server error")
-		codeError = errors.ParseCoder(err)
-	}
-	if codeError == nil {
-		err = errors.WithCode(code.ErrInternalServer, "%s", "internal server error")
-		codeError = errors.ParseCoder(err)
-	}
-	errorCode := codeError.Code()
+        codeError := errors.ParseCoder(err)
+        if codeError == nil {
+                err = code.WrapInternalServerError(err, "internal server error")
+                codeError = errors.ParseCoder(err)
+        }
+        if codeError == nil {
+                err = errors.WithCode(code.ErrInternalServer, "%s", "internal server error")
+                codeError = errors.ParseCoder(err)
+        }
+        errorCode := codeError.Code()
 
-	// 获取HTTP状态码（只支持200,400,401,403,404,500）
-	httpStatus := code.HTTPStatus(errorCode)
+        httpStatus := code.HTTPStatus(errorCode)
 
-	// 构建错误响应
-	rjson := ErrorResponse{
-		Code:      errorCode,
-		Message:   codeError.String(),
-		RequestID: getRequestID(c),
-		Timestamp: time.Now().Unix(),
-	}
+        rjson := ErrorResponse{
+                Code:      errorCode,
+                Message:   codeError.String(),
+                RequestID: getRequestID(c),
+                Timestamp: time.Now().Unix(),
+        }
 
-	// 统一记录错误日志（所有错误都打印到日志）
-	logError(err, errorCode, codeError.String(), rjson.RequestID, c)
+        logError(err, errorCode, codeError.String(), rjson.RequestID, c)
 
-	// 返回对应的HTTP状态码
-	return c.JSON(httpStatus, rjson)
+        return c.JSON(httpStatus, rjson)
 }
 
 // logError 统一错误日志记录
 func logError(err error, errorCode int, message, requestID string, c echo.Context) {
-	// 构建基础日志字段
-	fields := []slog.Attr{
-		slog.Int("code", errorCode),
-		slog.String("message", message),
-		slog.String("request_id", requestID),
-		slog.String("method", c.Request().Method),
-		slog.String("uri", c.Request().RequestURI),
-		slog.String("user_agent", c.Request().UserAgent()),
-		slog.String("error", err.Error()),
-	}
+        fields := []slog.Attr{
+                slog.Int("code", errorCode),
+                slog.String("message", message),
+                slog.String("request_id", requestID),
+                slog.String("method", c.Request().Method),
+                slog.String("uri", c.Request().RequestURI),
+                slog.String("user_agent", c.Request().UserAgent()),
+                slog.String("error", err.Error()),
+        }
 
-	// 根据错误类型选择日志级别
-	if code.IsInternalError(errorCode) {
-		// 内部错误：记录详细日志
-		log.Error("Internal Error", fields...)
-	} else {
-		// 业务错误：记录警告日志
-		log.Warn("Business Error", fields...)
-	}
+        if code.IsInternalError(errorCode) {
+                log.Error("Internal Error", fields...)
+        } else {
+                log.Warn("Business Error", fields...)
+        }
 }
 
-// getRequestID 获取请求ID
+func OperateSuccess(c echo.Context) error {
+        var rjson struct {
+                Code int    `json:"code"`
+                Msg  string `json:"msg"`
+        }
+
+        rjson.Msg = "success"
+
+        return c.JSON(http.StatusOK, rjson)
+}
+
+func ListDataResponse(arr interface{}, total int64, c echo.Context) error {
+        if arr == nil {
+                arr = make([]interface{}, 0)
+        } else if reflect.ValueOf(arr).IsNil() {
+                arr = make([]interface{}, 0)
+        }
+
+        r := ListResponse{
+                Data: ListData{
+                        List:  arr,
+                        Total: total,
+                },
+        }
+
+        return c.JSONPretty(http.StatusOK, r, "  ")
+}
+
+func OneDataResponse(data interface{}, c echo.Context) error {
+        r := DataResponse{
+                Data: data,
+        }
+
+        return c.JSON(http.StatusOK, r)
+}
+
+// getRequestID 获取请求ID，用于错误追踪
 func getRequestID(c echo.Context) string {
-	requestID := c.Request().Header.Get("X-Request-ID")
-	if requestID == "" {
-		requestID = uuid.New().String()
-	}
-	return requestID
+        if requestID := c.Request().Header.Get("X-Request-ID"); requestID != "" {
+                return requestID
+        }
+
+        if requestID := c.Response().Header().Get("X-Request-ID"); requestID != "" {
+                return requestID
+        }
+
+        requestID := generateRequestID()
+        c.Response().Header().Set("X-Request-ID", requestID)
+        return requestID
 }
 
-// Success 成功响应
-func Success(data interface{}) *DataResponse {
-	return &DataResponse{
-		Code: 200,
-		Msg:  "success",
-		Data: data,
-	}
-}
-
-// ListDataResponse 列表数据响应
-func ListDataResponse(list interface{}, total int64, c echo.Context) error {
-	return c.JSON(http.StatusOK, ListResponse{
-		Code: 200,
-		Msg:  "success",
-		Data: ListData{
-			Total: total,
-			List:  list,
-		},
-	})
-}
-
-// Error 错误响应
-func Error(code int, message string) *DataResponse {
-	return &DataResponse{
-		Code: code,
-		Msg:  message,
-	}
-}
-
-// JSON 返回JSON响应
-func JSON(c echo.Context, statusCode int, response interface{}) error {
-	return c.JSON(statusCode, response)
-}
-
-// SuccessJSON 成功JSON响应
-func SuccessJSON(c echo.Context, data interface{}) error {
-	return c.JSON(http.StatusOK, Success(data))
-}
-
-// ErrorJSON 错误JSON响应
-func ErrorJSON(c echo.Context, statusCode int, message string) error {
-	return c.JSON(statusCode, Error(statusCode, message))
-}
-
-// IsNil 检查值是否为nil
-func IsNil(i interface{}) bool {
-	if i == nil {
-		return true
-	}
-	switch reflect.TypeOf(i).Kind() {
-	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
-		return reflect.ValueOf(i).IsNil()
-	}
-	return false
+func generateRequestID() string {
+        return uuid.NewString()
 }

--- a/muban/project/templates/internal/resp/response_test.go.tmpl
+++ b/muban/project/templates/internal/resp/response_test.go.tmpl
@@ -1,52 +1,80 @@
 package resp
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"testing"
+        "errors"
+        "net/http/httptest"
+        "testing"
 
-	"github.com/labstack/echo/v4"
-	"github.com/stretchr/testify/assert"
+        "github.com/labstack/echo/v4"
 )
 
-func TestSuccess(t *testing.T) {
-	data := map[string]string{"message": "test"}
-	response := Success(data)
-
-	assert.Equal(t, 200, response.Code)
-	assert.Equal(t, "success", response.Message)
-	assert.Equal(t, data, response.Data)
+func getContext() echo.Context {
+        e := echo.New()
+        req := httptest.NewRequest(http.MethodGet, "/", nil)
+        req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+        rec := httptest.NewRecorder()
+        return e.NewContext(req, rec)
 }
 
-func TestError(t *testing.T) {
-	response := Error(400, "Bad Request")
+func TestAPIError(t *testing.T) {
+        tests := []struct {
+                name    string
+                err     error
+                wantErr bool
+        }{
+                {
+                        name:    "with error",
+                        err:     errors.New("api error"),
+                        wantErr: false,
+                },
+                {
+                        name:    "nil error",
+                        err:     nil,
+                        wantErr: true,
+                },
+        }
 
-	assert.Equal(t, 400, response.Code)
-	assert.Equal(t, "Bad Request", response.Message)
-	assert.Nil(t, response.Data)
+        for _, tt := range tests {
+                t.Run(tt.name, func(t *testing.T) {
+                        if err := APIError(tt.err, getContext()); (err != nil) != tt.wantErr {
+                                t.Errorf("APIError() error = %v, wantErr %v", err, tt.wantErr)
+                        }
+                })
+        }
 }
 
-func TestSuccessJSON(t *testing.T) {
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-
-	data := map[string]string{"message": "test"}
-	err := SuccessJSON(c, data)
-
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusOK, rec.Code)
+func TestOperateSuccess(t *testing.T) {
+        if err := OperateSuccess(getContext()); err != nil {
+                t.Fatalf("OperateSuccess() error = %v", err)
+        }
 }
 
-func TestErrorJSON(t *testing.T) {
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+func TestListDataResponse(t *testing.T) {
+        tests := []struct {
+                name    string
+                arr     interface{}
+                total   int64
+                wantErr bool
+        }{
+                {
+                        name:    "nil list",
+                        arr:     nil,
+                        total:   0,
+                        wantErr: false,
+                },
+        }
 
-	err := ErrorJSON(c, http.StatusBadRequest, "Bad Request")
+        for _, tt := range tests {
+                t.Run(tt.name, func(t *testing.T) {
+                        if err := ListDataResponse(tt.arr, tt.total, getContext()); (err != nil) != tt.wantErr {
+                                t.Errorf("ListDataResponse() error = %v, wantErr %v", err, tt.wantErr)
+                        }
+                })
+        }
+}
 
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+func TestOneDataResponse(t *testing.T) {
+        if err := OneDataResponse(nil, getContext()); err != nil {
+                t.Fatalf("OneDataResponse() error = %v", err)
+        }
 }

--- a/muban/project/templates/internal/utils/context.go.tmpl
+++ b/muban/project/templates/internal/utils/context.go.tmpl
@@ -1,56 +1,101 @@
 package utils
 
 import (
-	"context"
-	"time"
+        "context"
+        "time"
+
+        "github.com/labstack/echo/v4"
 )
 
-// ContextKey 上下文键类型
-type ContextKey string
-
-const (
-	// UserIDKey 用户ID键
-	UserIDKey ContextKey = "user_id"
-	// UsernameKey 用户名键
-	UsernameKey ContextKey = "username"
-	// RequestIDKey 请求ID键
-	RequestIDKey ContextKey = "request_id"
-)
-
-// WithUserID 添加上下文中的用户ID
-func WithUserID(ctx context.Context, userID uint) context.Context {
-	return context.WithValue(ctx, UserIDKey, userID)
+// TraceContext 链路追踪上下文信息
+type TraceContext struct {
+        TraceID   string
+        SpanID    string
+        RequestID string
+        UserID    string
+        StartTime time.Time
 }
 
-// GetUserID 从上下文中获取用户ID
-func GetUserID(ctx context.Context) (uint, bool) {
-	userID, ok := ctx.Value(UserIDKey).(uint)
-	return userID, ok
+// ExtractTraceContext 从echo.Context中提取链路追踪信息
+func ExtractTraceContext(c echo.Context) *TraceContext {
+        tc := &TraceContext{
+                StartTime: time.Now(),
+        }
+
+        if requestID := c.Request().Header.Get("X-Request-ID"); requestID != "" {
+                tc.RequestID = requestID
+        } else if requestID := c.Response().Header().Get("X-Request-ID"); requestID != "" {
+                tc.RequestID = requestID
+        }
+
+        if traceID := c.Request().Header.Get("X-Trace-ID"); traceID != "" {
+                tc.TraceID = traceID
+        }
+        if spanID := c.Request().Header.Get("X-Span-ID"); spanID != "" {
+                tc.SpanID = spanID
+        }
+
+        if userID := c.Get("user_id"); userID != nil {
+                if uid, ok := userID.(string); ok {
+                        tc.UserID = uid
+                }
+        }
+
+        return tc
 }
 
-// WithUsername 添加上下文中的用户名
-func WithUsername(ctx context.Context, username string) context.Context {
-	return context.WithValue(ctx, UsernameKey, username)
+// BuildContext 构造包含链路追踪信息的标准context.Context
+func BuildContext(c echo.Context) context.Context {
+        ctx := c.Request().Context()
+        tc := ExtractTraceContext(c)
+
+        ctx = context.WithValue(ctx, "trace_id", tc.TraceID)
+        ctx = context.WithValue(ctx, "span_id", tc.SpanID)
+        ctx = context.WithValue(ctx, "request_id", tc.RequestID)
+        ctx = context.WithValue(ctx, "user_id", tc.UserID)
+        ctx = context.WithValue(ctx, "start_time", tc.StartTime)
+
+        return ctx
 }
 
-// GetUsername 从上下文中获取用户名
-func GetUsername(ctx context.Context) (string, bool) {
-	username, ok := ctx.Value(UsernameKey).(string)
-	return username, ok
+// GetTraceID 从context中获取TraceID
+func GetTraceID(ctx context.Context) string {
+        if traceID, ok := ctx.Value("trace_id").(string); ok {
+                return traceID
+        }
+        return ""
 }
 
-// WithRequestID 添加上下文中的请求ID
-func WithRequestID(ctx context.Context, requestID string) context.Context {
-	return context.WithValue(ctx, RequestIDKey, requestID)
+// GetRequestID 从context中获取RequestID
+func GetRequestID(ctx context.Context) string {
+        if requestID, ok := ctx.Value("request_id").(string); ok {
+                return requestID
+        }
+        return ""
 }
 
-// GetRequestID 从上下文中获取请求ID
-func GetRequestID(ctx context.Context) (string, bool) {
-	requestID, ok := ctx.Value(RequestIDKey).(string)
-	return requestID, ok
+// GetUserID 从context中获取UserID
+func GetUserID(ctx context.Context) string {
+        if userID, ok := ctx.Value("user_id").(string); ok {
+                return userID
+        }
+        return ""
 }
 
-// WithTimeout 添加上下文超时
-func WithTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(ctx, timeout)
+// GetStartTime 从context中获取请求开始时间
+func GetStartTime(ctx context.Context) time.Time {
+        if startTime, ok := ctx.Value("start_time").(time.Time); ok {
+                return startTime
+        }
+        return time.Now()
+}
+
+// WithTraceInfo 为context添加链路追踪信息
+func WithTraceInfo(ctx context.Context, traceID, spanID, requestID, userID string) context.Context {
+        ctx = context.WithValue(ctx, "trace_id", traceID)
+        ctx = context.WithValue(ctx, "span_id", spanID)
+        ctx = context.WithValue(ctx, "request_id", requestID)
+        ctx = context.WithValue(ctx, "user_id", userID)
+        ctx = context.WithValue(ctx, "start_time", time.Now())
+        return ctx
 }

--- a/muban/project/templates/internal/utils/context_test.go.tmpl
+++ b/muban/project/templates/internal/utils/context_test.go.tmpl
@@ -1,54 +1,253 @@
 package utils
 
 import (
-	"context"
-	"testing"
+        "context"
+        "net/http"
+        "net/http/httptest"
+        "testing"
+        "time"
+
+        "github.com/labstack/echo/v4"
+        "github.com/stretchr/testify/assert"
 )
 
-func TestWithUserID(t *testing.T) {
-	ctx := context.Background()
-	userID := uint(123)
-	
-	ctx = WithUserID(ctx, userID)
-	
-	retrievedID, ok := GetUserID(ctx)
-	if !ok {
-		t.Fatal("expected to get user ID from context")
-	}
-	
-	if retrievedID != userID {
-		t.Errorf("expected user ID %d, got %d", userID, retrievedID)
-	}
+func TestExtractTraceContext(t *testing.T) {
+        tests := []struct {
+                name          string
+                headers       map[string]string
+                userID        interface{}
+                expectedTrace *TraceContext
+        }{
+                {
+                        name: "complete trace info",
+                        headers: map[string]string{
+                                "X-Request-ID": "req-123",
+                                "X-Trace-ID":   "trace-456",
+                                "X-Span-ID":    "span-789",
+                        },
+                        userID: "user-001",
+                        expectedTrace: &TraceContext{
+                                TraceID:   "trace-456",
+                                SpanID:    "span-789",
+                                RequestID: "req-123",
+                                UserID:    "user-001",
+                        },
+                },
+                {
+                        name: "minimal trace info",
+                        headers: map[string]string{
+                                "X-Request-ID": "req-456",
+                        },
+                        userID: nil,
+                        expectedTrace: &TraceContext{
+                                TraceID:   "",
+                                SpanID:    "",
+                                RequestID: "req-456",
+                                UserID:    "",
+                        },
+                },
+                {
+                        name:    "no trace info",
+                        headers: map[string]string{},
+                        userID:  nil,
+                        expectedTrace: &TraceContext{
+                                TraceID:   "",
+                                SpanID:    "",
+                                RequestID: "",
+                                UserID:    "",
+                        },
+                },
+        }
+
+        for _, tt := range tests {
+                t.Run(tt.name, func(t *testing.T) {
+                        e := echo.New()
+                        req := httptest.NewRequest(http.MethodGet, "/test", nil)
+                        for key, value := range tt.headers {
+                                req.Header.Set(key, value)
+                        }
+
+                        rec := httptest.NewRecorder()
+                        c := e.NewContext(req, rec)
+
+                        if tt.userID != nil {
+                                c.Set("user_id", tt.userID)
+                        }
+
+                        trace := ExtractTraceContext(c)
+
+                        assert.Equal(t, tt.expectedTrace.TraceID, trace.TraceID)
+                        assert.Equal(t, tt.expectedTrace.SpanID, trace.SpanID)
+                        assert.Equal(t, tt.expectedTrace.RequestID, trace.RequestID)
+                        assert.Equal(t, tt.expectedTrace.UserID, trace.UserID)
+                        assert.NotZero(t, trace.StartTime)
+                })
+        }
 }
 
-func TestWithUsername(t *testing.T) {
-	ctx := context.Background()
-	username := "testuser"
-	
-	ctx = WithUsername(ctx, username)
-	
-	retrievedUsername, ok := GetUsername(ctx)
-	if !ok {
-		t.Fatal("expected to get username from context")
-	}
-	
-	if retrievedUsername != username {
-		t.Errorf("expected username %s, got %s", username, retrievedUsername)
-	}
+func TestBuildContext(t *testing.T) {
+        e := echo.New()
+        req := httptest.NewRequest(http.MethodGet, "/test", nil)
+        req.Header.Set("X-Request-ID", "req-123")
+        req.Header.Set("X-Trace-ID", "trace-456")
+        req.Header.Set("X-Span-ID", "span-789")
+
+        rec := httptest.NewRecorder()
+        c := e.NewContext(req, rec)
+        c.Set("user_id", "user-001")
+
+        ctx := BuildContext(c)
+
+        assert.Equal(t, "trace-456", GetTraceID(ctx))
+        assert.Equal(t, "span-789", ctx.Value("span_id"))
+        assert.Equal(t, "req-123", GetRequestID(ctx))
+        assert.Equal(t, "user-001", GetUserID(ctx))
+        assert.NotZero(t, GetStartTime(ctx))
 }
 
-func TestWithRequestID(t *testing.T) {
-	ctx := context.Background()
-	requestID := "req-123"
-	
-	ctx = WithRequestID(ctx, requestID)
-	
-	retrievedRequestID, ok := GetRequestID(ctx)
-	if !ok {
-		t.Fatal("expected to get request ID from context")
-	}
-	
-	if retrievedRequestID != requestID {
-		t.Errorf("expected request ID %s, got %s", requestID, retrievedRequestID)
-	}
+func TestGetTraceID(t *testing.T) {
+        tests := []struct {
+                name     string
+                ctx      context.Context
+                expected string
+        }{
+                {
+                        name:     "with trace ID",
+                        ctx:      context.WithValue(context.Background(), "trace_id", "trace-123"),
+                        expected: "trace-123",
+                },
+                {
+                        name:     "without trace ID",
+                        ctx:      context.Background(),
+                        expected: "",
+                },
+                {
+                        name:     "invalid trace ID type",
+                        ctx:      context.WithValue(context.Background(), "trace_id", 123),
+                        expected: "",
+                },
+        }
+
+        for _, tt := range tests {
+                t.Run(tt.name, func(t *testing.T) {
+                        result := GetTraceID(tt.ctx)
+                        assert.Equal(t, tt.expected, result)
+                })
+        }
+}
+
+func TestGetRequestID(t *testing.T) {
+        tests := []struct {
+                name     string
+                ctx      context.Context
+                expected string
+        }{
+                {
+                        name:     "with request ID",
+                        ctx:      context.WithValue(context.Background(), "request_id", "req-123"),
+                        expected: "req-123",
+                },
+                {
+                        name:     "without request ID",
+                        ctx:      context.Background(),
+                        expected: "",
+                },
+                {
+                        name:     "invalid request ID type",
+                        ctx:      context.WithValue(context.Background(), "request_id", 123),
+                        expected: "",
+                },
+        }
+
+        for _, tt := range tests {
+                t.Run(tt.name, func(t *testing.T) {
+                        result := GetRequestID(tt.ctx)
+                        assert.Equal(t, tt.expected, result)
+                })
+        }
+}
+
+func TestGetUserID(t *testing.T) {
+        tests := []struct {
+                name     string
+                ctx      context.Context
+                expected string
+        }{
+                {
+                        name:     "with user ID",
+                        ctx:      context.WithValue(context.Background(), "user_id", "user-123"),
+                        expected: "user-123",
+                },
+                {
+                        name:     "without user ID",
+                        ctx:      context.Background(),
+                        expected: "",
+                },
+                {
+                        name:     "invalid user ID type",
+                        ctx:      context.WithValue(context.Background(), "user_id", 123),
+                        expected: "",
+                },
+        }
+
+        for _, tt := range tests {
+                t.Run(tt.name, func(t *testing.T) {
+                        result := GetUserID(tt.ctx)
+                        assert.Equal(t, tt.expected, result)
+                })
+        }
+}
+
+func TestGetStartTime(t *testing.T) {
+        now := time.Now()
+
+        tests := []struct {
+                name     string
+                ctx      context.Context
+                expected time.Time
+        }{
+                {
+                        name:     "with start time",
+                        ctx:      context.WithValue(context.Background(), "start_time", now),
+                        expected: now,
+                },
+                {
+                        name:     "without start time",
+                        ctx:      context.Background(),
+                        expected: time.Now(),
+                },
+                {
+                        name:     "invalid start time type",
+                        ctx:      context.WithValue(context.Background(), "start_time", "invalid"),
+                        expected: time.Now(),
+                },
+        }
+
+        for _, tt := range tests {
+                t.Run(tt.name, func(t *testing.T) {
+                        result := GetStartTime(tt.ctx)
+                        if tt.name == "with start time" {
+                                assert.Equal(t, tt.expected, result)
+                        } else {
+                                assert.True(t, result.After(now.Add(-time.Second)))
+                                assert.True(t, result.Before(now.Add(time.Second)))
+                        }
+                })
+        }
+}
+
+func TestWithTraceInfo(t *testing.T) {
+        ctx := context.Background()
+        traceID := "trace-123"
+        spanID := "span-456"
+        requestID := "req-789"
+        userID := "user-001"
+
+        newCtx := WithTraceInfo(ctx, traceID, spanID, requestID, userID)
+
+        assert.Equal(t, traceID, GetTraceID(newCtx))
+        assert.Equal(t, spanID, newCtx.Value("span_id"))
+        assert.Equal(t, requestID, GetRequestID(newCtx))
+        assert.Equal(t, userID, GetUserID(newCtx))
+        assert.NotZero(t, GetStartTime(newCtx))
 }


### PR DESCRIPTION
## Summary
- add BuildContext, trace context helpers, and corresponding tests to the utils template so generated services compile
- align the response helpers template (and tests) with the concrete implementation, including OneDataResponse and OperateSuccess
- update the example router template to rely on the shared response helpers instead of undefined helpers

## Testing
- not run (go test ./... hangs in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d7bf51dfac832d8ab6689176c758dd