### PR TITLE
Use templates for support file generation

### DIFF
--- a/internal/utils/context_trace.go
+++ b/internal/utils/context_trace.go
@@ -1,0 +1,5 @@
+package utils
+
+// Deprecated: 该文件仅用于兼容早期依赖 `context_trace.go` 的代码。
+// 链路追踪相关的实现已经迁移至 context.go。本文件保持为空以避免在
+// 旧项目中出现重复定义的问题，同时也提醒开发者迁移到新的实现。

--- a/muban/modgen/templates/template_renderer.go
+++ b/muban/modgen/templates/template_renderer.go
@@ -76,6 +76,8 @@ func loadRenderer() (*TemplateRenderer, error) {
 		"service_test_enhanced",
 		"biz_test_enhanced",
 		"code_openapi",
+		"context_support",
+		"resp_support",
 	}
 
 	if templateDir, err := locateTemplateDir(); err == nil {
@@ -195,6 +197,16 @@ func (tr *TemplateRenderer) RenderBiz(pascal, packagePath string) (string, error
 		PackagePath: packagePath,
 	}
 	return tr.Render("biz", data)
+}
+
+// RenderContextSupport 生成 utils 上下文支持文件
+func (tr *TemplateRenderer) RenderContextSupport() (string, error) {
+	return tr.Render("context_support", TemplateData{})
+}
+
+// RenderRespSupport 生成 resp 辅助函数文件
+func (tr *TemplateRenderer) RenderRespSupport() (string, error) {
+	return tr.Render("resp_support", TemplateData{})
 }
 
 // RenderService 生成服务层模板

--- a/muban/modgen/templates/template_renderer_test.go
+++ b/muban/modgen/templates/template_renderer_test.go
@@ -102,6 +102,62 @@ func TestRenderService(t *testing.T) {
 	}
 }
 
+func TestRenderContextSupport(t *testing.T) {
+	renderer, err := NewTemplateRenderer()
+	if err != nil {
+		t.Fatalf("创建模板渲染器失败: %v", err)
+	}
+
+	content, err := renderer.RenderContextSupport()
+	if err != nil {
+		t.Fatalf("渲染 context 支持模板失败: %v", err)
+	}
+
+	checks := []string{
+		"package utils",
+		"type TraceContext struct",
+		"func ExtractTraceContext",
+		"func BuildContext",
+		"func GetTraceID",
+		"func GetRequestID",
+		"func GetUserID",
+		"func GetStartTime",
+		"func WithTraceInfo",
+	}
+
+	for _, expected := range checks {
+		if !strings.Contains(content, expected) {
+			t.Errorf("context 支持模板缺少内容: %s", expected)
+		}
+	}
+}
+
+func TestRenderRespSupport(t *testing.T) {
+	renderer, err := NewTemplateRenderer()
+	if err != nil {
+		t.Fatalf("创建模板渲染器失败: %v", err)
+	}
+
+	content, err := renderer.RenderRespSupport()
+	if err != nil {
+		t.Fatalf("渲染 resp 支持模板失败: %v", err)
+	}
+
+	checks := []string{
+		"package resp",
+		"type operateSuccessBody struct",
+		"type singleDataBody struct",
+		"func OperateSuccess",
+		"func OneDataResponse",
+	}
+
+	for _, expected := range checks {
+		if !strings.Contains(content, expected) {
+			t.Errorf("resp 支持模板缺少内容: %s", expected)
+		}
+	}
+}
+
 func TestRenderParam(t *testing.T) {
 	renderer, err := NewTemplateRenderer()
 	if err != nil {

--- a/muban/modgen/templates/tmpl/context_support.tmpl
+++ b/muban/modgen/templates/tmpl/context_support.tmpl
@@ -1,0 +1,94 @@
+package utils
+
+import (
+    "context"
+    "time"
+
+    "github.com/labstack/echo/v4"
+)
+
+type TraceContext struct {
+    TraceID   string
+    SpanID    string
+    RequestID string
+    UserID    string
+    StartTime time.Time
+}
+
+func ExtractTraceContext(c echo.Context) *TraceContext {
+    tc := &TraceContext{
+        StartTime: time.Now(),
+    }
+
+    if requestID := c.Request().Header.Get("X-Request-ID"); requestID != "" {
+        tc.RequestID = requestID
+    } else if requestID := c.Response().Header().Get("X-Request-ID"); requestID != "" {
+        tc.RequestID = requestID
+    }
+
+    if traceID := c.Request().Header.Get("X-Trace-ID"); traceID != "" {
+        tc.TraceID = traceID
+    }
+
+    if spanID := c.Request().Header.Get("X-Span-ID"); spanID != "" {
+        tc.SpanID = spanID
+    }
+
+    if userID := c.Get("user_id"); userID != nil {
+        if uid, ok := userID.(string); ok {
+            tc.UserID = uid
+        }
+    }
+
+    return tc
+}
+
+func BuildContext(c echo.Context) context.Context {
+    ctx := c.Request().Context()
+    tc := ExtractTraceContext(c)
+
+    ctx = context.WithValue(ctx, "trace_id", tc.TraceID)
+    ctx = context.WithValue(ctx, "span_id", tc.SpanID)
+    ctx = context.WithValue(ctx, "request_id", tc.RequestID)
+    ctx = context.WithValue(ctx, "user_id", tc.UserID)
+    ctx = context.WithValue(ctx, "start_time", tc.StartTime)
+
+    return ctx
+}
+
+func GetTraceID(ctx context.Context) string {
+    if traceID, ok := ctx.Value("trace_id").(string); ok {
+        return traceID
+    }
+    return ""
+}
+
+func GetRequestID(ctx context.Context) string {
+    if requestID, ok := ctx.Value("request_id").(string); ok {
+        return requestID
+    }
+    return ""
+}
+
+func GetUserID(ctx context.Context) string {
+    if userID, ok := ctx.Value("user_id").(string); ok {
+        return userID
+    }
+    return ""
+}
+
+func GetStartTime(ctx context.Context) time.Time {
+    if startTime, ok := ctx.Value("start_time").(time.Time); ok {
+        return startTime
+    }
+    return time.Now()
+}
+
+func WithTraceInfo(ctx context.Context, traceID, spanID, requestID, userID string) context.Context {
+    ctx = context.WithValue(ctx, "trace_id", traceID)
+    ctx = context.WithValue(ctx, "span_id", spanID)
+    ctx = context.WithValue(ctx, "request_id", requestID)
+    ctx = context.WithValue(ctx, "user_id", userID)
+    ctx = context.WithValue(ctx, "start_time", time.Now())
+    return ctx
+}

--- a/muban/modgen/templates/tmpl/resp_support.tmpl
+++ b/muban/modgen/templates/tmpl/resp_support.tmpl
@@ -1,0 +1,35 @@
+package resp
+
+import (
+    "net/http"
+
+    "github.com/labstack/echo/v4"
+)
+
+type operateSuccessBody struct {
+    Code int    `json:"code"`
+    Msg  string `json:"msg"`
+}
+
+type singleDataBody struct {
+    Code int         `json:"code"`
+    Msg  string      `json:"msg"`
+    Data interface{} `json:"data"`
+}
+
+func OperateSuccess(c echo.Context) error {
+    payload := operateSuccessBody{
+        Code: http.StatusOK,
+        Msg:  "success",
+    }
+    return c.JSON(http.StatusOK, payload)
+}
+
+func OneDataResponse(data interface{}, c echo.Context) error {
+    payload := singleDataBody{
+        Code: http.StatusOK,
+        Msg:  "success",
+        Data: data,
+    }
+    return c.JSON(http.StatusOK, payload)
+}


### PR DESCRIPTION
## Summary
- replace inline support file strings with template-driven rendering in the generator
- add dedicated context and resp helper templates plus renderer helpers
- extend template tests to cover the new support templates

## Testing
- go test ./muban/modgen/...

------
https://chatgpt.com/codex/tasks/task_e_68d7da3cff3c832dbedd2354db9995a3