### PR TITLE
refactor: align module templates with repository pattern

### DIFF
--- a/muban/modgen/templates/template_renderer.go
+++ b/muban/modgen/templates/template_renderer.go
@@ -62,6 +62,7 @@ func loadRenderer() (*TemplateRenderer, error) {
 	funcMap := template.FuncMap{
 		"hasPrefix": strings.HasPrefix,
 		"contains":  strings.Contains,
+		"upper":     strings.ToUpper,
 	}
 
 	templateNames := []string{

--- a/muban/modgen/templates/tmpl/biz.tmpl
+++ b/muban/modgen/templates/tmpl/biz.tmpl
@@ -1,121 +1,79 @@
 package biz
 
 import (
-	"context"
-	"{{.PackagePath}}/internal/api/data"
-	"{{.PackagePath}}/internal/api/data/model"
-	"{{.PackagePath}}/internal/api/service/param"
+"context"
+
+"{{.PackagePath}}/internal/api/service/param"
+"{{.PackagePath}}/internal/code"
 )
+
+// {{.Pascal}}Repository 定义数据访问接口，便于依赖注入
+type {{.Pascal}}Repository interface {
+List(ctx context.Context, p param.{{.Pascal}}Param) ([]param.{{.Pascal}}Response, int64, error)
+Create(ctx context.Context, b param.{{.Pascal}}Body) error
+Update(ctx context.Context, id int64, b param.{{.Pascal}}Body) error
+Delete(ctx context.Context, id int64) error
+Detail(ctx context.Context, id int64) (param.{{.Pascal}}Response, error)
+}
 
 // {{.Pascal}}UseCase {{.Pascal}}业务用例接口
 type {{.Pascal}}UseCase interface {
-	List(ctx context.Context, p param.{{.Pascal}}Param) ([]param.{{.Pascal}}Response, int64, error)
-	Create(ctx context.Context, b param.{{.Pascal}}Body) error
-	Update(ctx context.Context, id int64, b param.{{.Pascal}}Body) error
-	Delete(ctx context.Context, id int64) error
-	Detail(ctx context.Context, id int64) (*param.{{.Pascal}}Response, error)
+List(ctx context.Context, p param.{{.Pascal}}Param) ([]param.{{.Pascal}}Response, int64, error)
+Create(ctx context.Context, b param.{{.Pascal}}Body) error
+Update(ctx context.Context, id int64, b param.{{.Pascal}}Body) error
+Delete(ctx context.Context, id int64) error
+Detail(ctx context.Context, id int64) (param.{{.Pascal}}Response, error)
 }
 
 // {{.Pascal}}Handler {{.Pascal}}业务处理器
 type {{.Pascal}}Handler struct {
-	dm *data.DataManager
+repo {{.Pascal}}Repository
 }
 
 // New{{.Pascal}}Handler 创建{{.Pascal}}业务处理器
-func New{{.Pascal}}Handler(dm *data.DataManager) *{{.Pascal}}Handler {
-	return &{{.Pascal}}Handler{dm: dm}
+func New{{.Pascal}}Handler(repo {{.Pascal}}Repository) {{.Pascal}}UseCase {
+return &{{.Pascal}}Handler{repo: repo}
 }
 
 // List 获取{{.Pascal}}列表
 func (h *{{.Pascal}}Handler) List(ctx context.Context, p param.{{.Pascal}}Param) ([]param.{{.Pascal}}Response, int64, error) {
-	// TODO: 实现列表查询逻辑
-	// 示例：
-	// var models []model.{{.Pascal}}
-	// if err := h.dm.MySQLWithContext(ctx).Offset(p.Offset()).Limit(p.Limit()).Find(&models).Error; err != nil {
-	//     return nil, 0, code.WrapDatabaseError(err, "query {{.Pascal}} list")
-	// }
-	// var total int64
-	// h.dm.MySQLWithContext(ctx).Model(&model.{{.Pascal}}{}).Count(&total)
-	// return convert{{.Pascal}}ToResponses(models), total, nil
-	return nil, 0, nil
+list, total, err := h.repo.List(ctx, p)
+if err != nil {
+return nil, 0, code.WrapDatabaseError(err, "查询{{.Pascal}}列表失败")
+}
+
+return list, total, nil
 }
 
 // Create 创建{{.Pascal}}
 func (h *{{.Pascal}}Handler) Create(ctx context.Context, b param.{{.Pascal}}Body) error {
-	// TODO: 实现创建逻辑
-	// 示例：
-	// model := &model.{{.Pascal}}{
-	//     // 设置字段
-	//     CreatedAt: time.Now(),
-	// }
-	// if err := h.dm.MySQLWithContext(ctx).Create(model).Error; err != nil {
-	//     return nil, code.WrapDatabaseError(err, "create {{.Pascal}}")
-	// }
-	// 创建成功
-	return nil
+if err := h.repo.Create(ctx, b); err != nil {
+return code.WrapDatabaseError(err, "创建{{.Pascal}}失败")
+}
+return nil
 }
 
 // Update 更新{{.Pascal}}
 func (h *{{.Pascal}}Handler) Update(ctx context.Context, id int64, b param.{{.Pascal}}Body) error {
-	// TODO: 实现更新逻辑
-	// 示例：
-	// var model model.{{.Pascal}}
-	// if err := h.dm.MySQLWithContext(ctx).First(&model, id).Error; err != nil {
-	//     if errors.Is(err, gorm.ErrRecordNotFound) {
-	//         return nil, code.WrapNotFoundError(nil, "{{.Pascal}} not found")
-	//     }
-	//     return nil, code.WrapDatabaseError(err, "query {{.Pascal}}")
-	// }
-	// // 更新字段
-	// model.UpdatedAt = time.Now()
-	// if err := h.dm.MySQLWithContext(ctx).Save(&model).Error; err != nil {
-	//     return code.WrapDatabaseError(err, "update {{.Pascal}}")
-	// }
-	// 更新成功
-	return nil
+if err := h.repo.Update(ctx, id, b); err != nil {
+return code.WrapDatabaseError(err, "更新{{.Pascal}}失败")
+}
+return nil
 }
 
 // Delete 删除{{.Pascal}}
 func (h *{{.Pascal}}Handler) Delete(ctx context.Context, id int64) error {
-	// TODO: 实现删除逻辑
-	// 示例：
-	// if err := h.dm.MySQLWithContext(ctx).Delete(&model.{{.Pascal}}{}, id).Error; err != nil {
-	//     return code.WrapDatabaseError(err, "delete {{.Pascal}}")
-	// }
-	// return nil
-	return nil
+if err := h.repo.Delete(ctx, id); err != nil {
+return code.WrapDatabaseError(err, "删除{{.Pascal}}失败")
+}
+return nil
 }
 
 // Detail 获取{{.Pascal}}详情
-func (h *{{.Pascal}}Handler) Detail(ctx context.Context, id int64) (*param.{{.Pascal}}Response, error) {
-	// TODO: 实现详情查询逻辑
-	// 示例：
-	// var model model.{{.Pascal}}
-	// if err := h.dm.MySQLWithContext(ctx).First(&model, id).Error; err != nil {
-	//     if errors.Is(err, gorm.ErrRecordNotFound) {
-	//         return nil, code.WrapNotFoundError(nil, "{{.Pascal}} not found")
-	//     }
-	//     return nil, code.WrapDatabaseError(err, "query {{.Pascal}}")
-	// }
-	// return convert{{.Pascal}}ToResponse(&model), nil
-	return nil, nil
+func (h *{{.Pascal}}Handler) Detail(ctx context.Context, id int64) (param.{{.Pascal}}Response, error) {
+result, err := h.repo.Detail(ctx, id)
+if err != nil {
+return result, code.WrapDatabaseError(err, "查询{{.Pascal}}详情失败")
 }
-
-// convert{{.Pascal}}ToResponse 转换为响应结构
-func convert{{.Pascal}}ToResponse(model *model.{{.Pascal}}) *param.{{.Pascal}}Response {
-	// TODO: 实现转换逻辑
-	return &param.{{.Pascal}}Response{
-		// ID: model.ID,
-		// CreatedAt: model.CreatedAt,
-		// UpdatedAt: model.UpdatedAt,
-	}
-}
-
-// convert{{.Pascal}}ToResponses 转换为响应结构列表
-func convert{{.Pascal}}ToResponses(models []model.{{.Pascal}}) []param.{{.Pascal}}Response {
-	responses := make([]param.{{.Pascal}}Response, len(models))
-	for i, model := range models {
-		responses[i] = *convert{{.Pascal}}ToResponse(&model)
-	}
-	return responses
+return result, nil
 }

--- a/muban/modgen/templates/tmpl/biz_openapi.tmpl
+++ b/muban/modgen/templates/tmpl/biz_openapi.tmpl
@@ -6,146 +6,60 @@
 package biz
 
 import (
-	{{if .Operations}}"context"{{end}}
-	"{{.PackagePath}}/internal/api/data"
-	{{if .Operations}}"{{.PackagePath}}/internal/api/service/param"{{end}}
+"context"
+
+"{{.PackagePath}}/internal/api/service/param"
+"{{.PackagePath}}/internal/code"
 )
+
+// {{.Pascal}}Repository 数据访问接口 - 符合依赖注入原则
+type {{.Pascal}}Repository interface {
+{{- range .Operations }}
+// {{.MethodName}} {{if .Summary}}{{.Summary}}{{else}}处理{{$.Pascal}}{{end}}
+{{.MethodName}}(ctx context.Context{{- if .HasPathParams }}, id int64{{- end }}{{- if .HasRequestBodyOrQuery }}, req param.{{$.Pascal}}{{.MethodName}}Request{{- end }}) {{- if and .ResponseData (eq .ResponseData.GoType "ListItem")}}([]param.{{$.Pascal}}ListItem, int64, error){{- else if .ResponseData}}(param.{{$.Pascal}}{{.ResponseData.GoType}}, error){{- else}}error{{- end }}
+{{- end }}
+}
 
 // {{.Pascal}}UseCase 业务逻辑接口
 type {{.Pascal}}UseCase interface {
-{{range .Operations}}
-	// {{.MethodName}} {{.Summary}}
-	{{.MethodName}}(ctx context.Context{{if .HasPathParams}}, id int64{{end}}{{if .HasRequestBodyOrQuery}}, req param.{{$.Pascal}}{{.MethodName}}Request{{end}}) {{if and .ResponseData (eq .ResponseData.GoType "ListItem")}}([]param.{{$.Pascal}}ListItem, int64, error){{else if .ResponseData}}({{if eq .ResponseData.GoType "Data"}}*{{end}}param.{{$.Pascal}}{{.ResponseData.GoType}}, error){{else}}error{{end}}
-{{end}}
+{{- range .Operations }}
+// {{.MethodName}} {{if .Summary}}{{.Summary}}{{else}}处理{{$.Pascal}}{{end}}
+{{.MethodName}}(ctx context.Context{{- if .HasPathParams }}, id int64{{- end }}{{- if .HasRequestBodyOrQuery }}, req param.{{$.Pascal}}{{.MethodName}}Request{{- end }}) {{- if and .ResponseData (eq .ResponseData.GoType "ListItem")}}([]param.{{$.Pascal}}ListItem, int64, error){{- else if .ResponseData}}(param.{{$.Pascal}}{{.ResponseData.GoType}}, error){{- else}}error{{- end }}
+{{- end }}
 }
 
-// {{.Pascal}}Handler 业务逻辑处理器
+// {{.Pascal}}Handler 业务逻辑处理器 - 通过依赖注入获取Repository
 type {{.Pascal}}Handler struct {
-	dataManager *data.DataManager
-	// TODO: 注入其他依赖
+repo {{.Pascal}}Repository
 }
 
-// New{{.Pascal}}Handler 创建业务逻辑处理器
-func New{{.Pascal}}Handler(dataManager *data.DataManager) {{.Pascal}}UseCase {
-	return &{{.Pascal}}Handler{
-		dataManager: dataManager,
-	}
+// New{{.Pascal}}Handler 创建业务逻辑处理器 - 符合依赖注入原则
+func New{{.Pascal}}Handler(repo {{.Pascal}}Repository) {{.Pascal}}UseCase {
+return &{{.Pascal}}Handler{
+repo: repo,
+}
 }
 
-// TODO: 实现业务逻辑方法
-
-{{range .Operations}}
-func (h *{{$.Pascal}}Handler) {{.MethodName}}(ctx context.Context{{if .HasPathParams}}, id int64{{end}}{{if .HasRequestBodyOrQuery}}, req param.{{$.Pascal}}{{.MethodName}}Request{{end}}) {{if and .ResponseData (eq .ResponseData.GoType "ListItem")}}([]param.{{$.Pascal}}ListItem, int64, error){{else if .ResponseData}}({{if eq .ResponseData.GoType "Data"}}*{{end}}param.{{$.Pascal}}{{.ResponseData.GoType}}, error){{else}}error{{end}} {
-	// TODO: 实现业务逻辑
-	{{if and .ResponseData (eq .ResponseData.GoType "ListItem")}}
-	// TODO: 实现查询逻辑
-	// 使用带context的数据库查询 - context包含链路追踪信息
-	// db := h.dataManager.MySQLWithContext(ctx)
-	// query := h.dataManager.Query.WithContext(ctx)
-	// 
-	// 示例实现：
-	// var users []model.{{$.Pascal}}
-	// var total int64
-	// 
-	// // 构建查询条件
-	// query := h.dataManager.Query.{{$.Pascal}}.WithContext(ctx)
-	// if req.Name != "" {
-	// 	query = query.Where(h.dataManager.Query.{{$.Pascal}}.Name.Like("%%" + req.Name + "%%"))
-	// }
-	// if req.Email != "" {
-	// 	query = query.Where(h.dataManager.Query.{{$.Pascal}}.Account.Eq(req.Email))
-	// }
-	// 
-	// // 分页查询
-	// offset := (req.Page - 1) * req.Count
-	// err := query.Count(&total).Offset(offset).Limit(req.Count).Find(&users)
-	// if err != nil {
-	// 	return nil, 0, err
-	// }
-	// 
-	// // 转换为响应格式
-	// var responses []param.{{$.Pascal}}Response
-	// for _, user := range users {
-	// 	responses = append(responses, param.{{$.Pascal}}Response{
-	// 		ID:   user.ID,
-	// 		Name: user.Name,
-	// 	})
-	// }
-	// 
-	// return responses, total, nil
-	return nil, 0, nil
-	{{else if eq .MethodName "Create"}}
-	// TODO: 实现创建逻辑
-	// 使用带context的数据库操作 - context包含链路追踪信息
-	// db := h.dataManager.MySQLWithContext(ctx)
-	// 
-	// 示例实现：
-	// user := model.{{$.Pascal}}{
-	// 	Name:    req.Name,
-	// 	Account: req.Account,
-	// 	Phone:   req.Phone,
-	// 	Status:  req.Status,
-	// }
-	// 
-	// err := h.dataManager.Query.{{$.Pascal}}.WithContext(ctx).Create(&user)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// 
-	// return &param.{{$.Pascal}}Data{
-	// 	ID:   user.ID,
-	// 	Name: user.Name,
-	// }, nil
-	return nil, nil
-	{{else if .ResponseData}}
-	// TODO: 实现根据ID查询逻辑
-	// 使用带context的数据库查询 - context包含链路追踪信息
-	// 
-	// 示例实现：
-	// var user model.{{$.Pascal}}
-	// err := h.dataManager.Query.{{$.Pascal}}.WithContext(ctx).Where(h.dataManager.Query.{{$.Pascal}}.ID.Eq(id)).First(&user)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// 
-	// return &param.{{$.Pascal}}Data{
-	// 	ID:   user.ID,
-	// 	Name: user.Name,
-	// }, nil
-	return nil, nil
-	{{else if eq .MethodName "Update"}}
-	// TODO: 实现更新逻辑
-	// 使用带context的数据库操作 - context包含链路追踪信息
-	// 
-	// 示例实现：
-	// updates := map[string]interface{}{
-	// 	"name":   req.Name,
-	// 	"phone":  req.Phone,
-	// 	"status": req.Status,
-	// }
-	// 
-	// err := h.dataManager.Query.{{$.Pascal}}.WithContext(ctx).Where(h.dataManager.Query.{{$.Pascal}}.ID.Eq(id)).Updates(updates)
-	// if err != nil {
-	// 	return err
-	// }
-	// 
-	// return nil
-	return nil
-	{{else if eq .MethodName "Delete"}}
-	// TODO: 实现删除逻辑
-	// 使用带context的数据库操作 - context包含链路追踪信息
-	// 
-	// 示例实现：
-	// err := h.dataManager.Query.{{$.Pascal}}.WithContext(ctx).Where(h.dataManager.Query.{{$.Pascal}}.ID.Eq(id)).Delete(&model.{{$.Pascal}}{})
-	// if err != nil {
-	// 	return err
-	// }
-	// 
-	// return nil
-	return nil
-	{{else}}
-	// TODO: 实现业务逻辑
-	return nil
-	{{end}}
+{{- range .Operations }}
+func (h *{{$.Pascal}}Handler) {{.MethodName}}(ctx context.Context{{- if .HasPathParams }}, id int64{{- end }}{{- if .HasRequestBodyOrQuery }}, req param.{{$.Pascal}}{{.MethodName}}Request{{- end }}) {{- if and .ResponseData (eq .ResponseData.GoType "ListItem")}}([]param.{{$.Pascal}}ListItem, int64, error){{- else if .ResponseData}}(param.{{$.Pascal}}{{.ResponseData.GoType}}, error){{- else}}error{{- end }} {
+{{- if and .ResponseData (eq .ResponseData.GoType "ListItem") }}
+list, total, err := h.repo.{{.MethodName}}(ctx{{- if and .HasPathParams .HasRequestBodyOrQuery}}, id, req{{- else if .HasPathParams }}, id{{- else if .HasRequestBodyOrQuery }}, req{{- end }})
+if err != nil {
+return nil, 0, code.WrapDatabaseError(err, "{{if .Summary}}{{.Summary}}{{else}}{{$.Pascal}}{{.MethodName}}{{end}}失败")
 }
-{{end}}
+return list, total, nil
+{{- else if .ResponseData }}
+result, err := h.repo.{{.MethodName}}(ctx{{- if and .HasPathParams .HasRequestBodyOrQuery}}, id, req{{- else if .HasPathParams }}, id{{- else if .HasRequestBodyOrQuery }}, req{{- end }})
+if err != nil {
+return result, code.WrapDatabaseError(err, "{{if .Summary}}{{.Summary}}{{else}}{{$.Pascal}}{{.MethodName}}{{end}}失败")
+}
+return result, nil
+{{- else }}
+if err := h.repo.{{.MethodName}}(ctx{{- if and .HasPathParams .HasRequestBodyOrQuery}}, id, req{{- else if .HasPathParams }}, id{{- else if .HasRequestBodyOrQuery }}, req{{- end }}); err != nil {
+return code.WrapDatabaseError(err, "{{if .Summary}}{{.Summary}}{{else}}{{$.Pascal}}{{.MethodName}}{{end}}失败")
+}
+return nil
+{{- end }}
+}
+
+{{- end }}

--- a/muban/modgen/templates/tmpl/service.tmpl
+++ b/muban/modgen/templates/tmpl/service.tmpl
@@ -1,69 +1,97 @@
 package service
 
 import (
-	"strconv"
-	"{{.PackagePath}}/internal/api/biz"
-	"{{.PackagePath}}/internal/api/service/param"
-	"{{.PackagePath}}/internal/resp"
-	"{{.PackagePath}}/internal/utils"
-	"github.com/labstack/echo/v4"
+"strconv"
+
+"{{.PackagePath}}/internal/api/biz"
+"{{.PackagePath}}/internal/api/service/param"
+"{{.PackagePath}}/internal/resp"
+"{{.PackagePath}}/internal/utils"
+"github.com/labstack/echo/v4"
 )
 
 type {{.Camel}}Controller struct {
-	{{.Camel}} biz.{{.Pascal}}UseCase
+{{.Camel}} biz.{{.Pascal}}UseCase
 }
 
-func New{{.Pascal}}Controller(h *biz.{{.Pascal}}Handler) RegisterRouter {
-	return &{{.Camel}}Controller{
-		{{.Camel}}: h,
-	}
+func New{{.Pascal}}Controller(h biz.{{.Pascal}}UseCase) RegisterRouter {
+return &{{.Camel}}Controller{
+{{.Camel}}: h,
+}
 }
 
 func (c *{{.Camel}}Controller) RegisterRouter(g *echo.Group, m ...echo.MiddlewareFunc) {
-	g.GET("{{.Route}}", c.list).Name = "列表示例"
-	g.POST("{{.Route}}", c.create).Name = "创建示例"
-	g.GET("{{.Route}}/:id", c.detail).Name = "详情示例"
-	g.PUT("{{.Route}}/:id", c.update).Name = "更新示例"
-	g.DELETE("{{.Route}}/:id", c.remove).Name = "删除示例"
+g.GET("{{.Route}}", c.list).Name = "列表示例"
+g.POST("{{.Route}}", c.create).Name = "创建示例"
+g.GET("{{.Route}}/:id", c.detail).Name = "详情示例"
+g.PUT("{{.Route}}/:id", c.update).Name = "更新示例"
+g.DELETE("{{.Route}}/:id", c.remove).Name = "删除示例"
 }
 
 func (c *{{.Camel}}Controller) list(ctx echo.Context) error {
-	var p param.{{.Pascal}}Param
-	if err := BindAndValidate(ctx, &p); err != nil { return err }
-	bizCtx := utils.BuildContext(ctx)
-	items, total, err := c.{{.Camel}}.List(bizCtx, p)
-	if err != nil { return err }
-	return resp.ListDataResponse(items, total, ctx)
+var p param.{{.Pascal}}Param
+if err := BindAndValidate(ctx, &p); err != nil {
+return err
+}
+
+bizCtx := utils.BuildContext(ctx)
+items, total, err := c.{{.Camel}}.List(bizCtx, p)
+if err != nil {
+return err
+}
+
+return resp.ListDataResponse(ctx, items, total)
 }
 
 func (c *{{.Camel}}Controller) detail(ctx echo.Context) error {
-	id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
-	bizCtx := utils.BuildContext(ctx)
-	item, err := c.{{.Camel}}.Detail(bizCtx, id)
-	if err != nil { return err }
-	return resp.OneDataResponse(item, ctx)
+id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
+
+bizCtx := utils.BuildContext(ctx)
+item, err := c.{{.Camel}}.Detail(bizCtx, id)
+if err != nil {
+return err
+}
+
+return resp.OneDataResponse(ctx, item)
 }
 
 func (c *{{.Camel}}Controller) create(ctx echo.Context) error {
-	var b param.{{.Pascal}}Body
-	if err := BindAndValidate(ctx, &b); err != nil { return err }
-	bizCtx := utils.BuildContext(ctx)
-	if err := c.{{.Camel}}.Create(bizCtx, b); err != nil { return err }
-	return resp.OperateSuccess(ctx)
+var b param.{{.Pascal}}Body
+if err := BindAndValidate(ctx, &b); err != nil {
+return err
+}
+
+bizCtx := utils.BuildContext(ctx)
+if err := c.{{.Camel}}.Create(bizCtx, b); err != nil {
+return err
+}
+
+return resp.OperateSuccess(ctx)
 }
 
 func (c *{{.Camel}}Controller) update(ctx echo.Context) error {
-	id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
-	var b param.{{.Pascal}}Body
-	if err := BindAndValidate(ctx, &b); err != nil { return err }
-	bizCtx := utils.BuildContext(ctx)
-	if err := c.{{.Camel}}.Update(bizCtx, id, b); err != nil { return err }
-	return resp.OperateSuccess(ctx)
+id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
+
+var b param.{{.Pascal}}Body
+if err := BindAndValidate(ctx, &b); err != nil {
+return err
+}
+
+bizCtx := utils.BuildContext(ctx)
+if err := c.{{.Camel}}.Update(bizCtx, id, b); err != nil {
+return err
+}
+
+return resp.OperateSuccess(ctx)
 }
 
 func (c *{{.Camel}}Controller) remove(ctx echo.Context) error {
-	id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
-	bizCtx := utils.BuildContext(ctx)
-	if err := c.{{.Camel}}.Delete(bizCtx, id); err != nil { return err }
-	return resp.OperateSuccess(ctx)
+id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
+
+bizCtx := utils.BuildContext(ctx)
+if err := c.{{.Camel}}.Delete(bizCtx, id); err != nil {
+return err
+}
+
+return resp.OperateSuccess(ctx)
 }

--- a/muban/modgen/templates/tmpl/service_openapi.tmpl
+++ b/muban/modgen/templates/tmpl/service_openapi.tmpl
@@ -6,176 +6,72 @@
 package service
 
 import (
-{{if .HasPathParams}}	"strconv"
-{{end}}	"{{.PackagePath}}/internal/api/biz"
-	{{if .Operations}}"{{.PackagePath}}/internal/api/service/param"
-	"{{.PackagePath}}/internal/resp"
-	"{{.PackagePath}}/internal/utils"{{end}}
-	"github.com/labstack/echo/v4"
+{{- if .HasPathParams }}
+"strconv"
+{{- end }}
+"{{.PackagePath}}/internal/api/biz"
+"{{.PackagePath}}/internal/api/service/param"
+"{{.PackagePath}}/internal/resp"
+"{{.PackagePath}}/internal/utils"
+"github.com/labstack/echo/v4"
 )
 
 type {{.Pascal}}Controller struct {
-	{{.Camel}} biz.{{.Pascal}}UseCase
+{{.Camel}} biz.{{.Pascal}}UseCase
 }
 
 func New{{.Pascal}}Controller(h biz.{{.Pascal}}UseCase) RegisterRouter {
-	return &{{.Pascal}}Controller{ {{.Camel}}: h }
+return &{{.Pascal}}Controller{
+{{.Camel}}: h,
+}
 }
 
 func (c *{{.Pascal}}Controller) RegisterRouter(g *echo.Group, m ...echo.MiddlewareFunc) {
-{{range .Operations}}
-	g.{{if eq .Method "get"}}GET{{else if eq .Method "post"}}POST{{else if eq .Method "put"}}PUT{{else if eq .Method "delete"}}DELETE{{else}}{{.Method}}{{end}}("{{.Path}}", c.{{.MethodName}}).Name = "{{.Summary}}"
-{{end}}
+{{- range .Operations }}
+g.{{- if eq .Method "get" -}}GET{{- else if eq .Method "post" -}}POST{{- else if eq .Method "put" -}}PUT{{- else if eq .Method "delete" -}}DELETE{{- else -}}{{.Method | upper}}{{- end}}("{{.Path}}", c.{{.MethodName}}).Name = "{{.Summary}}"
+{{- end }}
 }
 
-// TODO: 实现控制器方法
+{{- range .Operations }}
+func (c *{{$.Pascal}}Controller) {{.MethodName}}(ctx echo.Context) error {
+{{- if .HasRequestBodyOrQuery }}
+// 绑定和验证请求参数
+var req param.{{$.Pascal}}{{.MethodName}}Request
+if err := BindAndValidate(ctx, &req); err != nil {
+return err
+}
+{{- end }}
+{{- if .HasPathParams }}
+// 获取路径参数
+id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
+{{- end }}
 
-{{range .Operations}}
-{{if and .ResponseData (eq .ResponseData.GoType "ListItem")}}
-func (c *{{$.Pascal}}Controller) {{.MethodName}}(ctx echo.Context) error {
-	{{if .HasRequestBodyOrQuery}}// TODO: 绑定和验证请求参数
-	var req param.{{$.Pascal}}{{.MethodName}}Request
-	if err := BindAndValidate(ctx, &req); err != nil {
-		return err
-	}
-	{{end}}
-	{{if .HasPathParams}}// 获取路径参数
-	id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
-	{{end}}
-	
-	// 调用业务逻辑 - 构造包含链路追踪信息的context
-	bizCtx := utils.BuildContext(ctx)
-	{{if and .HasRequestBodyOrQuery .HasPathParams}}list, total, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, id, req){{else if .HasRequestBodyOrQuery}}list, total, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, req){{else if .HasPathParams}}list, total, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, id){{else}}list, total, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx){{end}}
-	if err != nil {
-		return err
-	}
-	
-	// 返回列表数据
-	return resp.ListDataResponse(list, total, ctx)
+// 调用业务逻辑 - 构造包含链路追踪信息的context
+bizCtx := utils.BuildContext(ctx)
+{{- if and .ResponseData (eq .ResponseData.GoType "ListItem") }}
+list, total, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx{{- if and .HasPathParams .HasRequestBodyOrQuery}}, id, req{{- else if .HasPathParams }}, id{{- else if .HasRequestBodyOrQuery }}, req{{- end }})
+if err != nil {
+return err
 }
-{{else if or (eq .MethodName "Create") (hasPrefix .MethodName "Create")}}
-func (c *{{$.Pascal}}Controller) {{.MethodName}}(ctx echo.Context) error {
-	{{if .HasPathParams}}
-	// 获取路径参数
-	id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
-	{{end}}
-	
-	// TODO: 绑定和验证请求参数
-	var req param.{{$.Pascal}}{{.MethodName}}Request
-	if err := BindAndValidate(ctx, &req); err != nil {
-		return err
-	}
-	
-	// 调用业务逻辑 - 构造包含链路追踪信息的context
-	bizCtx := utils.BuildContext(ctx)
-	{{if and .ResponseData (eq .ResponseData.GoType "Data")}}{{if .HasPathParams}}result, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, id, req){{else}}result, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, req){{end}}
-	if err != nil {
-		return err
-	}
-	
-	// 返回数据
-	return resp.OneDataResponse(result, ctx){{else}}{{if .HasPathParams}}if err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, id, req); err != nil {
-		return err
-	}{{else}}if err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, req); err != nil {
-		return err
-	}{{end}}
-	
-	// 返回操作成功
-	return resp.OperateSuccess(ctx){{end}}
+
+// 返回列表数据 - 使用统一的响应格式
+return resp.ListDataResponse(ctx, list, total)
+{{- else if .ResponseData }}
+result, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx{{- if and .HasPathParams .HasRequestBodyOrQuery}}, id, req{{- else if .HasPathParams }}, id{{- else if .HasRequestBodyOrQuery }}, req{{- end }})
+if err != nil {
+return err
 }
-{{else if or (eq .MethodName "GetByID") (hasPrefix .MethodName "Get")}}
-func (c *{{$.Pascal}}Controller) {{.MethodName}}(ctx echo.Context) error {
-	// 获取路径参数
-	id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
-	
-	// 调用业务逻辑 - 构造包含链路追踪信息的context
-	bizCtx := utils.BuildContext(ctx)
-	result, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, id)
-	if err != nil {
-		return err
-	}
-	
-	// 返回数据
-	return resp.OneDataResponse(result, ctx)
+
+// 返回数据 - 使用统一的响应格式
+return resp.OneDataResponse(ctx, result)
+{{- else }}
+if err := c.{{$.Camel}}.{{.MethodName}}(bizCtx{{- if and .HasPathParams .HasRequestBodyOrQuery}}, id, req{{- else if .HasPathParams }}, id{{- else if .HasRequestBodyOrQuery }}, req{{- end }}); err != nil {
+return err
 }
-{{else if or (eq .MethodName "Update") (hasPrefix .MethodName "Update")}}
-func (c *{{$.Pascal}}Controller) {{.MethodName}}(ctx echo.Context) error {
-	// 获取路径参数
-	id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
-	
-	// 绑定和验证请求体参数
-	var req param.{{$.Pascal}}{{.MethodName}}Request
-	if err := BindAndValidate(ctx, &req); err != nil {
-		return err
-	}
-	
-	// 调用业务逻辑 - 构造包含链路追踪信息的context
-	bizCtx := utils.BuildContext(ctx)
-	{{if and .ResponseData (eq .ResponseData.GoType "Data")}}result, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, id, req)
-	if err != nil {
-		return err
-	}
-	
-	// 返回数据
-	return resp.OneDataResponse(result, ctx){{else}}if err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, id, req); err != nil {
-		return err
-	}
-	
-	// 返回操作成功
-	return resp.OperateSuccess(ctx){{end}}
+
+// 返回操作成功 - 使用统一的响应格式
+return resp.OperateSuccess(ctx)
+{{- end }}
 }
-{{else if or (eq .MethodName "Delete") (hasPrefix .MethodName "Delete")}}
-func (c *{{$.Pascal}}Controller) {{.MethodName}}(ctx echo.Context) error {
-	// 获取路径参数
-	id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
-	
-	// 调用业务逻辑 - 构造包含链路追踪信息的context
-	bizCtx := utils.BuildContext(ctx)
-	{{if and .ResponseData (eq .ResponseData.GoType "Data")}}result, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, id)
-	if err != nil {
-		return err
-	}
-	
-	// 返回数据
-	return resp.OneDataResponse(result, ctx){{else}}if err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, id); err != nil {
-		return err
-	}
-	
-	// 返回操作成功
-	return resp.OperateSuccess(ctx){{end}}
-}
-{{else}}
-func (c *{{$.Pascal}}Controller) {{.MethodName}}(ctx echo.Context) error {
-	{{if .HasRequestBodyOrQuery}}// TODO: 绑定和验证请求参数
-	var req param.{{$.Pascal}}{{.MethodName}}Request
-	if err := BindAndValidate(ctx, &req); err != nil {
-		return err
-	}
-	{{end}}
-	{{if .HasPathParams}}// 获取路径参数
-	id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
-	{{end}}
-	
-	// 调用业务逻辑 - 构造包含链路追踪信息的context
-	bizCtx := utils.BuildContext(ctx)
-	{{if and .ResponseData (eq .ResponseData.GoType "Data")}}{{if and .HasRequestBodyOrQuery .HasPathParams}}result, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, id, req){{else if .HasRequestBodyOrQuery}}result, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, req){{else if .HasPathParams}}result, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, id){{else}}result, err := c.{{$.Camel}}.{{.MethodName}}(bizCtx){{end}}
-	if err != nil {
-		return err
-	}
-	
-	// 返回数据
-	return resp.OneDataResponse(result, ctx){{else}}{{if and .HasRequestBodyOrQuery .HasPathParams}}if err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, id, req); err != nil {
-		return err
-	}{{else if .HasRequestBodyOrQuery}}if err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, req); err != nil {
-		return err
-	}{{else if .HasPathParams}}if err := c.{{$.Camel}}.{{.MethodName}}(bizCtx, id); err != nil {
-		return err
-	}{{else}}if err := c.{{$.Camel}}.{{.MethodName}}(bizCtx); err != nil {
-		return err
-	}{{end}}
-	
-	// 返回操作成功
-	return resp.OperateSuccess(ctx){{end}}
-}
-{{end}}
-{{end}}
+
+{{- end }}


### PR DESCRIPTION
## Summary
- update OpenAPI service templates to consistently bind/validate requests, build context, and emit unified resp helpers
- refactor OpenAPI biz template to inject repository interfaces and wrap persistence errors with the code package
- refresh default service/biz templates and template renderer helpers to mirror the new structure

## Testing
- `go test ./...` *(fails: existing internal/api/biz/user_test.go still expects the legacy DataManager-based handler and request fields)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ec628e30832d8c49c9d3015a631c