### PR TITLE
Escape literal braces in casbin query template

### DIFF
--- a/muban/project/templates/internal/api/data/query/casbin_rule.gen.go.tmpl
+++ b/muban/project/templates/internal/api/data/query/casbin_rule.gen.go.tmpl
@@ -432,13 +432,13 @@ func (c casbinRuleDo) GetInactive() (result []model.CasbinRule, err error) {
 
 // FilterWithCondition - 使用where模板表达式
 // SELECT * FROM @@table
-// {{where}}
+// {{"{{"}}where{{"}}"}}
 //
-//	{{if condition != ""}}
+//	{{"{{"}}if condition != ""{{"}}"}}
 //	  @condition
-//	{{end}}
+//	{{"{{"}}end{{"}}"}}
 //
-// {{end}}
+// {{"{{"}}end{{"}}"}}
 func (c casbinRuleDo) FilterWithCondition(condition string) (result []model.CasbinRule, err error) {
 	var params []interface{}
 
@@ -460,16 +460,16 @@ func (c casbinRuleDo) FilterWithCondition(condition string) (result []model.Casb
 
 // FilterWithTime - 使用if/else模板表达式
 // SELECT * FROM @@table
-// {{if !start.IsZero()}}
+// {{"{{"}}if !start.IsZero(){{"}}"}}
 //
 //	WHERE created_at > @start
 //
-// {{end}}
-// {{if !end.IsZero()}}
+// {{"{{"}}end{{"}}"}}
+// {{"{{"}}if !end.IsZero(){{"}}"}}
 //
 //	AND created_at < @end
 //
-// {{end}}
+// {{"{{"}}end{{"}}"}}
 func (c casbinRuleDo) FilterWithTime(start time.Time, end time.Time) (result []model.CasbinRule, err error) {
 	var params []interface{}
 
@@ -493,13 +493,13 @@ func (c casbinRuleDo) FilterWithTime(start time.Time, end time.Time) (result []m
 
 // UpdateWithSet - 使用set模板表达式
 // UPDATE @@table
-// {{set}}
+// {{"{{"}}set{{"}}"}}
 //
-//	{{if name != ""}} name=@name, {{end}}
-//	{{if age > 0}} age=@age, {{end}}
+//	{{"{{"}}if name != ""{{"}}"}} name=@name, {{"{{"}}end{{"}}"}}
+//	{{"{{"}}if age > 0{{"}}"}} age=@age, {{"{{"}}end{{"}}"}}
 //	updated_at=NOW()
 //
-// {{end}}
+// {{"{{"}}end{{"}}"}}
 // WHERE id=@id
 func (c casbinRuleDo) UpdateWithSet(name string, age int, id uint) (err error) {
 	var params []interface{}


### PR DESCRIPTION
## Summary
- escape the illustrative dynamic SQL template markers in the casbin_rule query template so text/template parsing no longer requires undefined helpers

## Testing
- go test ./... *(hangs in current environment, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68d8fddfd454832d9ad31f9e657f1266