### PR TITLE
Fix middleware templates to use utils JWT claims

### DIFF
--- a/muban/project/templates/internal/server/middlewares/casbin.go.tmpl
+++ b/muban/project/templates/internal/server/middlewares/casbin.go.tmpl
@@ -9,8 +9,8 @@
 package middlewares
 
 import (
-	"{{.ModulePath}}/internal/api/data"
 	"{{.ModulePath}}/internal/code"
+	"{{.ModulePath}}/internal/utils"
 	"github.com/casbin/casbin/v2"
 	"github.com/golang-jwt/jwt/v5"
 	casbin_mw "github.com/labstack/echo-contrib/casbin"
@@ -71,7 +71,7 @@ func Casbin(enforce *casbin.Enforcer, config *CasbinConfig) echo.MiddlewareFunc 
 				return "", nil
 			}
 
-			user := token.Claims.(*data.JwtCustomClaims)
+			user := token.Claims.(*utils.JwtCustomClaims)
 			if user == nil {
 				return "", nil
 			}

--- a/muban/project/templates/internal/server/middlewares/jwt.go.tmpl
+++ b/muban/project/templates/internal/server/middlewares/jwt.go.tmpl
@@ -12,8 +12,8 @@ import (
 	"fmt"
 	"strings"
 
-	"{{.ModulePath}}/internal/api/data"
 	"{{.ModulePath}}/internal/code"
+	"{{.ModulePath}}/internal/utils"
 	"github.com/golang-jwt/jwt/v5"
 	echojwt "github.com/labstack/echo-jwt/v4"
 	"github.com/labstack/echo/v4"
@@ -54,7 +54,7 @@ func JWT(config *JWTConfig) echo.MiddlewareFunc {
 
 	return echojwt.WithConfig(echojwt.Config{
 		NewClaimsFunc: func(c echo.Context) jwt.Claims {
-			return new(data.JwtCustomClaims)
+			return new(utils.JwtCustomClaims)
 		},
 		SigningKey: config.SigningKey,
 		Skipper: func(c echo.Context) bool {


### PR DESCRIPTION
## Summary
- update the casbin middleware template to reference JwtCustomClaims from the utils package
- update the jwt middleware template to use the utils-based JwtCustomClaims helper after it moved out of data

## Testing
- not run (go test ./... hung while resolving modules)


------
https://chatgpt.com/codex/tasks/task_e_68d8ffd99b50832d8b2798f2c5695283