### PR TITLE
Add template for JWT custom claims and harden Casbin middleware

### DIFF
--- a/internal/server/middlewares/casbin.go
+++ b/internal/server/middlewares/casbin.go
@@ -71,7 +71,10 @@ func Casbin(enforce *casbin.Enforcer, config *CasbinConfig) echo.MiddlewareFunc 
 				return "", nil
 			}
 
-			user := token.Claims.(*utils.JwtCustomClaims)
+			user, ok := token.Claims.(*utils.JwtCustomClaims)
+			if !ok {
+				return "", errors.WrapC(errors.New("invalid token claims type"), code.ErrSignatureInvalid, "JWT签名无效")
+			}
 			if user == nil {
 				return "", nil
 			}

--- a/muban/project/templates/internal/server/middlewares/casbin.go.tmpl
+++ b/muban/project/templates/internal/server/middlewares/casbin.go.tmpl
@@ -71,7 +71,10 @@ func Casbin(enforce *casbin.Enforcer, config *CasbinConfig) echo.MiddlewareFunc 
 				return "", nil
 			}
 
-			user := token.Claims.(*utils.JwtCustomClaims)
+			user, ok := token.Claims.(*utils.JwtCustomClaims)
+			if !ok {
+				return "", errors.WrapC(errors.New("invalid token claims type"), code.ErrSignatureInvalid, "JWT签名无效")
+			}
 			if user == nil {
 				return "", nil
 			}

--- a/muban/project/templates/internal/utils/jwt.go.tmpl
+++ b/muban/project/templates/internal/utils/jwt.go.tmpl
@@ -1,0 +1,18 @@
+package utils
+
+import "github.com/golang-jwt/jwt/v5"
+
+// JwtCustomClaims 自定义 JWT Claims
+// 包含用户基本信息和标准注册声明
+//
+// 字段说明:
+//   - Name: 用户姓名
+//   - ID: 用户唯一标识
+//   - Admin: 是否为管理员
+//   - RegisteredClaims: JWT 标准注册声明（过期时间、签发时间等）
+type JwtCustomClaims struct {
+        Name  string `json:"name"`
+        ID    int64  `json:"id"`
+        Admin bool   `json:"admin"`
+        jwt.RegisteredClaims
+}


### PR DESCRIPTION
## Summary
- add the `JwtCustomClaims` helper to the internal utils template so generated projects compile when enabling JWT middleware
- guard the Casbin middleware implementation and template against invalid JWT claim types to avoid panics when tokens are misconfigured

## Testing
- not run (module download stalls in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d902a1ba2c832dbbfffa7d294fdae5