### PR TITLE
Align muban templates with new architecture

### DIFF
--- a/muban/modgen/templates/template_renderer_test.go
+++ b/muban/modgen/templates/template_renderer_test.go
@@ -54,9 +54,8 @@ func TestRenderBiz(t *testing.T) {
 		"func (h *UserHandler) Update",
 		"func (h *UserHandler) Delete",
 		"func (h *UserHandler) Detail",
-		"github.com/test/project/internal/api/data",
-		"github.com/test/project/internal/api/data/model",
 		"github.com/test/project/internal/api/service/param",
+		"github.com/NSObjects/go-kit/code",
 	}
 
 	for _, expected := range expectedContents {
@@ -80,14 +79,14 @@ func TestRenderService(t *testing.T) {
 	// 验证关键内容
 	expectedContents := []string{
 		"package service",
-		"type userController struct",
+		"type UserController struct",
 		"func NewUserController",
-		"func (c *userController) RegisterRouter",
-		"g.GET(\"/users\", c.list)",
-		"g.POST(\"/users\", c.create)",
-		"g.GET(\"/users/:id\", c.detail)",
-		"g.PUT(\"/users/:id\", c.update)",
-		"g.DELETE(\"/users/:id\", c.remove)",
+		"func (c *UserController) RegisterRouter",
+		"g.GET(\"/users\", c.List)",
+		"g.POST(\"/users\", c.Create)",
+		"g.GET(\"/users/:id\", c.Detail)",
+		"g.PUT(\"/users/:id\", c.Update)",
+		"g.DELETE(\"/users/:id\", c.Remove)",
 		"github.com/test/project/internal/api/biz",
 		"github.com/test/project/internal/api/service/param",
 		"github.com/NSObjects/go-kit/resp",

--- a/muban/modgen/templates/tmpl/biz.tmpl
+++ b/muban/modgen/templates/tmpl/biz.tmpl
@@ -4,7 +4,7 @@ import (
 "context"
 
 "{{.PackagePath}}/internal/api/service/param"
-"{{.PackagePath}}/internal/code"
+"github.com/NSObjects/go-kit/code"
 )
 
 // {{.Pascal}}Repository 定义数据访问接口，便于依赖注入

--- a/muban/modgen/templates/tmpl/biz_openapi.tmpl
+++ b/muban/modgen/templates/tmpl/biz_openapi.tmpl
@@ -9,7 +9,7 @@ import (
 "context"
 
 "{{.PackagePath}}/internal/api/service/param"
-"{{.PackagePath}}/internal/code"
+"github.com/NSObjects/go-kit/code"
 )
 
 // {{.Pascal}}Repository 数据访问接口 - 符合依赖注入原则

--- a/muban/modgen/templates/tmpl/data.tmpl
+++ b/muban/modgen/templates/tmpl/data.tmpl
@@ -1,106 +1,49 @@
 package data
 
 import (
-	"context"
+"context"
+"errors"
 
-	"{{.PackagePath}}/internal/api/biz"
-	"{{.PackagePath}}/internal/api/data/db"
-	"{{.PackagePath}}/internal/api/service/param"
-	"{{.PackagePath}}/internal/code"
+"{{.PackagePath}}/internal/api/biz"
+"{{.PackagePath}}/internal/api/data/db"
+"{{.PackagePath}}/internal/api/service/param"
+"github.com/NSObjects/go-kit/code"
 )
 
-// {{.Camel}}Repository 数据访问实现（小写开头，符合 Go 命名规范）
+// {{.Camel}}Repository 数据访问实现
 type {{.Camel}}Repository struct {
-	d *db.DataManager
+d *db.DataManager
 }
 
 // New{{.Pascal}}Repository 构造函数，供 fx 注入
 func New{{.Pascal}}Repository(d *db.DataManager) biz.{{.Pascal}}Repository {
-	return &{{.Camel}}Repository{d: d}
+return &{{.Camel}}Repository{d: d}
 }
 
 // List 获取{{.Pascal}}列表
 func (r *{{.Camel}}Repository) List(ctx context.Context, p param.{{.Pascal}}Param) ([]param.{{.Pascal}}Response, int64, error) {
-	// TODO: 实现数据访问逻辑
-	// 示例：
-	// items, err := r.d.Query.{{.Pascal}}.WithContext(ctx).Offset(p.Offset()).Limit(p.Limit()).Find()
-	// if err != nil {
-	// 	return nil, 0, code.WrapDatabaseError(err, "查询{{.Pascal}}列表失败")
-	// }
-	// count, err := r.d.Query.{{.Pascal}}.Count()
-	// if err != nil {
-	// 	return nil, 0, code.WrapDatabaseError(err, "查询{{.Pascal}}总数失败")
-	// }
-	// var list []param.{{.Pascal}}Response
-	// for _, item := range items {
-	// 	list = append(list, param.{{.Pascal}}Response{
-	// 		// TODO: 映射字段
-	// 	})
-	// }
-	// return list, count, nil
+var list []param.{{.Pascal}}Response
+var total int64
 
-	var list []param.{{.Pascal}}Response
-	var total int64
-	return list, total, nil
+return list, total, code.WrapDatabaseError(errors.New("{{.Pascal}} list not implemented"), "查询{{.Pascal}}列表失败")
 }
 
 // Create 创建{{.Pascal}}
 func (r *{{.Camel}}Repository) Create(ctx context.Context, b param.{{.Pascal}}Body) error {
-	// TODO: 实现数据访问逻辑
-	// 示例：
-	// item := model.{{.Pascal}}{
-	// 	// TODO: 映射字段
-	// 	CreatedAt: time.Now(),
-	// 	UpdatedAt: time.Now(),
-	// }
-	// if err := r.d.Query.{{.Pascal}}.WithContext(ctx).Create(&item); err != nil {
-	// 	return code.WrapDatabaseError(err, "创建{{.Pascal}}失败")
-	// }
-	// return nil
-
-	return nil
+return code.WrapDatabaseError(errors.New("{{.Pascal}} create not implemented"), "创建{{.Pascal}}失败")
 }
 
 // Update 更新{{.Pascal}}
 func (r *{{.Camel}}Repository) Update(ctx context.Context, id int64, b param.{{.Pascal}}Body) error {
-	// TODO: 实现数据访问逻辑
-	// 示例：
-	// _, err := r.d.Query.{{.Pascal}}.WithContext(ctx).Where(r.d.Query.{{.Pascal}}.ID.Eq(id)).Updates(model.{{.Pascal}}{
-	// 	// TODO: 映射字段
-	// 	UpdatedAt: time.Now(),
-	// })
-	// if err != nil {
-	// 	return code.WrapDatabaseError(err, "更新{{.Pascal}}失败")
-	// }
-	// return nil
-
-	return nil
+return code.WrapDatabaseError(errors.New("{{.Pascal}} update not implemented"), "更新{{.Pascal}}失败")
 }
 
 // Delete 删除{{.Pascal}}
 func (r *{{.Camel}}Repository) Delete(ctx context.Context, id int64) error {
-	// TODO: 实现数据访问逻辑
-	// 示例：
-	// if err := r.d.Query.{{.Pascal}}.WithContext(ctx).DeleteByID(uint(id)); err != nil {
-	// 	return code.WrapDatabaseError(err, "删除{{.Pascal}}失败")
-	// }
-	// return nil
-
-	return nil
+return code.WrapDatabaseError(errors.New("{{.Pascal}} delete not implemented"), "删除{{.Pascal}}失败")
 }
 
 // Detail 获取{{.Pascal}}详情
 func (r *{{.Camel}}Repository) Detail(ctx context.Context, id int64) (param.{{.Pascal}}Response, error) {
-	// TODO: 实现数据访问逻辑
-	// 示例：
-	// item, err := r.d.Query.{{.Pascal}}.WithContext(ctx).GetByID(uint(id))
-	// if err != nil {
-	// 	return param.{{.Pascal}}Response{}, code.WrapDatabaseError(err, "查询{{.Pascal}}详情失败")
-	// }
-	// return param.{{.Pascal}}Response{
-	// 	// TODO: 映射字段
-	// }, nil
-
-	return param.{{.Pascal}}Response{}, nil
+return param.{{.Pascal}}Response{}, code.WrapDatabaseError(errors.New("{{.Pascal}} detail not implemented"), "查询{{.Pascal}}详情失败")
 }
-

--- a/muban/modgen/templates/tmpl/data_openapi.tmpl
+++ b/muban/modgen/templates/tmpl/data_openapi.tmpl
@@ -7,40 +7,34 @@ package data
 
 import (
 "context"
+"errors"
 
 "{{.PackagePath}}/internal/api/biz"
-"{{.PackagePath}}/internal/api/service/param"
 "{{.PackagePath}}/internal/api/data/db"
+"{{.PackagePath}}/internal/api/service/param"
+"github.com/NSObjects/go-kit/code"
 )
 
 // {{.Camel}}Repository 数据访问实现（小写开头，符合 Go 命名规范）
 type {{.Camel}}Repository struct {
-    d *db.DataManager
+d *db.DataManager
 }
 
 // New{{.Pascal}}Repository 构造函数，供 fx 注入
 func New{{.Pascal}}Repository(d *db.DataManager) biz.{{.Pascal}}Repository {
-    return &{{.Camel}}Repository{d: d}
+return &{{.Camel}}Repository{d: d}
 }
 
 {{- range .Operations }}
 // {{.MethodName}} {{if .Summary}}{{.Summary}}{{else}}处理{{$.Pascal}}{{end}}
 func (r *{{$.Camel}}Repository) {{.MethodName}}(ctx context.Context{{- if .HasPathParams }}, id int64{{- end }}{{- if .HasRequestBodyOrQuery }}, req param.{{$.Pascal}}{{.MethodName}}Request{{- end }}) {{- if and .ResponseData (eq .ResponseData.GoType "ListItem")}}([]param.{{$.Pascal}}ListItem, int64, error){{- else if .ResponseData}}(param.{{$.Pascal}}{{.ResponseData.GoType}}, error){{- else}}error{{- end }} {
-    // TODO: 实现数据访问逻辑。以下为占位返回，便于通过编译。
-    {{- if and .ResponseData (eq .ResponseData.GoType "ListItem")}}
-    var list []param.{{$.Pascal}}ListItem
-    var total int64
-    return list, total, nil
-    {{- else if .ResponseData}}
-    var out param.{{$.Pascal}}{{.ResponseData.GoType}}
-    return out, nil
-    {{- else}}
-    return nil
-    {{- end }}
-    // 出错时请使用 internal/code 包进行包装，例如：
-    // import "{{.PackagePath}}/internal/code"
-    // return nil, 0, code.WrapDatabaseError(err, "说明信息")
+{{- if and .ResponseData (eq .ResponseData.GoType "ListItem")}}
+return nil, 0, code.WrapDatabaseError(errors.New("{{$.Pascal}}{{.MethodName}} not implemented"), "{{if .Summary}}{{.Summary}}{{else}}{{$.Pascal}}{{.MethodName}}{{end}}失败")
+{{- else if .ResponseData}}
+return param.{{$.Pascal}}{{.ResponseData.GoType}}{}, code.WrapDatabaseError(errors.New("{{$.Pascal}}{{.MethodName}} not implemented"), "{{if .Summary}}{{.Summary}}{{else}}{{$.Pascal}}{{.MethodName}}{{end}}失败")
+{{- else}}
+return code.WrapDatabaseError(errors.New("{{$.Pascal}}{{.MethodName}} not implemented"), "{{if .Summary}}{{.Summary}}{{else}}{{$.Pascal}}{{.MethodName}}{{end}}失败")
+{{- end }}
 }
 {{- end }}
-
 

--- a/muban/modgen/templates/tmpl/service.tmpl
+++ b/muban/modgen/templates/tmpl/service.tmpl
@@ -10,25 +10,23 @@ import (
 "github.com/labstack/echo/v4"
 )
 
-type {{.Camel}}Controller struct {
+type {{.Pascal}}Controller struct {
 {{.Camel}} biz.{{.Pascal}}UseCase
 }
 
 func New{{.Pascal}}Controller(h biz.{{.Pascal}}UseCase) RegisterRouter {
-return &{{.Camel}}Controller{
-{{.Camel}}: h,
-}
+return &{{.Pascal}}Controller{ {{.Camel}}: h }
 }
 
-func (c *{{.Camel}}Controller) RegisterRouter(g *echo.Group, m ...echo.MiddlewareFunc) {
-g.GET("{{.Route}}", c.list).Name = "列表示例"
-g.POST("{{.Route}}", c.create).Name = "创建示例"
-g.GET("{{.Route}}/:id", c.detail).Name = "详情示例"
-g.PUT("{{.Route}}/:id", c.update).Name = "更新示例"
-g.DELETE("{{.Route}}/:id", c.remove).Name = "删除示例"
+func (c *{{.Pascal}}Controller) RegisterRouter(g *echo.Group, m ...echo.MiddlewareFunc) {
+g.GET("{{.Route}}", c.List).Name = "列表示例"
+g.POST("{{.Route}}", c.Create).Name = "创建示例"
+g.GET("{{.Route}}/:id", c.Detail).Name = "详情示例"
+g.PUT("{{.Route}}/:id", c.Update).Name = "更新示例"
+g.DELETE("{{.Route}}/:id", c.Remove).Name = "删除示例"
 }
 
-func (c *{{.Camel}}Controller) list(ctx echo.Context) error {
+func (c *{{.Pascal}}Controller) List(ctx echo.Context) error {
 var p param.{{.Pascal}}Param
 if err := BindAndValidate(ctx, &p); err != nil {
 return err
@@ -43,7 +41,7 @@ return err
 return resp.ListDataResponse(ctx, items, total)
 }
 
-func (c *{{.Camel}}Controller) detail(ctx echo.Context) error {
+func (c *{{.Pascal}}Controller) Detail(ctx echo.Context) error {
 id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
 
 bizCtx := utils.BuildContext(ctx)
@@ -55,7 +53,7 @@ return err
 return resp.OneDataResponse(ctx, item)
 }
 
-func (c *{{.Camel}}Controller) create(ctx echo.Context) error {
+func (c *{{.Pascal}}Controller) Create(ctx echo.Context) error {
 var b param.{{.Pascal}}Body
 if err := BindAndValidate(ctx, &b); err != nil {
 return err
@@ -69,7 +67,7 @@ return err
 return resp.OperateSuccess(ctx)
 }
 
-func (c *{{.Camel}}Controller) update(ctx echo.Context) error {
+func (c *{{.Pascal}}Controller) Update(ctx echo.Context) error {
 id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
 
 var b param.{{.Pascal}}Body
@@ -85,7 +83,7 @@ return err
 return resp.OperateSuccess(ctx)
 }
 
-func (c *{{.Camel}}Controller) remove(ctx echo.Context) error {
+func (c *{{.Pascal}}Controller) Remove(ctx echo.Context) error {
 id, _ := strconv.ParseInt(ctx.Param("id"), 10, 64)
 
 bizCtx := utils.BuildContext(ctx)


### PR DESCRIPTION
## Summary
- update default module templates to use exported controllers and go-kit error handling that matches the current architecture
- revise OpenAPI-based biz and data templates to wrap database errors consistently and compile out of the box
- refresh template renderer tests to assert the new imports and handler signatures

## Testing
- go test ./... *(fails: module download blocked by proxy)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945292b5f7c832d9c630352332092c8)