### PR TITLE
Fix template config imports after muban generation

### DIFF
--- a/muban/project/templates/internal/api/data/db/db.go.tmpl
+++ b/muban/project/templates/internal/api/data/db/db.go.tmpl
@@ -7,16 +7,16 @@
 package db
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
 
-	"github.com/IBM/sarama"
-	"{{.ModulePath}}/internal/api/data/query"
-	"{{.ModulePath}}/internal/configs"
-	"github.com/redis/go-redis/v9"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.uber.org/fx"
-	"gorm.io/gorm"
+        "github.com/IBM/sarama"
+        configs "github.com/NSObjects/go-kit/config"
+        "{{.ModulePath}}/internal/api/data/query"
+        "github.com/redis/go-redis/v9"
+        "go.mongodb.org/mongo-driver/mongo"
+        "go.uber.org/fx"
+        "gorm.io/gorm"
 )
 
 // DataManager 统一的数据管理器，直接管理所有数据库组件

--- a/muban/project/templates/internal/api/data/db/kafka.go.tmpl
+++ b/muban/project/templates/internal/api/data/db/kafka.go.tmpl
@@ -5,8 +5,8 @@
 package db
 
 import (
-	"github.com/IBM/sarama"
-	"{{.ModulePath}}/internal/configs"
+        "github.com/IBM/sarama"
+        configs "github.com/NSObjects/go-kit/config"
 )
 
 func NewKafkaProducer(cfg configs.KafkaConfig) (sarama.SyncProducer, error) {

--- a/muban/project/templates/internal/server/config.go.tmpl
+++ b/muban/project/templates/internal/server/config.go.tmpl
@@ -9,9 +9,9 @@
 package server
 
 import (
-	"time"
+        "time"
 
-	"{{.ModulePath}}/internal/configs"
+        configs "github.com/NSObjects/go-kit/config"
 )
 
 // ServerConfig 服务器配置
@@ -47,13 +47,13 @@ func DefaultServerConfig() *ServerConfig {
 
 // FromAppConfig 从应用配置创建服务器配置
 func FromAppConfig(cfg configs.Config) *ServerConfig {
-	return &ServerConfig{
-		Port:            cfg.System.Port,
-		ReadTimeout:     30 * time.Second,
-		WriteTimeout:    30 * time.Second,
-		IdleTimeout:     120 * time.Second,
-		ShutdownTimeout: 10 * time.Second,
-		HideBanner:      true,
-		Debug:           cfg.System.Level == 1, // 1 = debug, 2 = online
-	}
+        return &ServerConfig{
+                Port:            cfg.System.Port,
+                ReadTimeout:     30 * time.Second,
+                WriteTimeout:    30 * time.Second,
+                IdleTimeout:     120 * time.Second,
+                ShutdownTimeout: 10 * time.Second,
+                HideBanner:      true,
+                Debug:           cfg.System.Level == "debug", // "debug" = debug mode
+        }
 }


### PR DESCRIPTION
## Summary
- update server config template to use go-kit config package and correct debug level check
- align data layer templates with go-kit config types to avoid undefined references
- ensure kafka template imports the proper config package

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69489d7f2d78832da62ea89b171a0f96)