### PR TITLE
Skip muban templates in generated project

### DIFF
--- a/muban/project/embed_template_generator.go
+++ b/muban/project/embed_template_generator.go
@@ -280,6 +280,10 @@ func (g *EmbedTemplateGenerator) printf(format string, args ...interface{}) {
 func (g *EmbedTemplateGenerator) shouldSkip(outputPath string) bool {
 	normalized := filepath.ToSlash(outputPath)
 
+	if strings.HasPrefix(normalized, "muban/") {
+		return true
+	}
+
 	if normalized == "go.sum" {
 		return true
 	}

--- a/muban/project/embed_template_generator_test.go
+++ b/muban/project/embed_template_generator_test.go
@@ -53,6 +53,10 @@ func TestGenerateProjectCreatesExecutableScripts(t *testing.T) {
 		t.Fatalf("expected go.sum to be skipped, got err=%v", err)
 	}
 
+	if _, err := os.Stat(filepath.Join(tempDir, "muban")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected muban assets to be skipped, got err=%v", err)
+	}
+
 	docsDir := filepath.Join(tempDir, "docs")
 	if entries, err := os.ReadDir(docsDir); err == nil {
 		for _, entry := range entries {


### PR DESCRIPTION
## Summary
- skip generating embedded `muban` directory assets so new projects only include application code
- add a regression test confirming the muban folder is omitted during template generation

## Testing
- `go test ./muban/...` *(fails: unable to download Go toolchain from proxy)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69489fcffe14832d932cb572b25fb87a)